### PR TITLE
fix: claim bond with no available rewards

### DIFF
--- a/features/claim-bond/claim-bond-form/claim-bond-form.tsx
+++ b/features/claim-bond/claim-bond-form/claim-bond-form.tsx
@@ -3,7 +3,10 @@ import { FC, memo } from 'react';
 import { ClaimBondFormProvider } from './context';
 
 import { FormBlock } from 'shared/components';
-import { FormControllerStyled } from 'shared/hook-form/form-controller';
+import {
+  BaseFormLoader,
+  FormControllerStyled,
+} from 'shared/hook-form/form-controller';
 import { ClaimBondFormInfo } from './claim-bond-form-info';
 import { AmountInput } from './controls/amount-input';
 import { SourceSelect } from './controls/source-select';
@@ -14,13 +17,15 @@ export const ClaimBondForm: FC = memo(() => {
   return (
     <ClaimBondFormProvider>
       <FormBlock>
-        <FormControllerStyled>
-          <SourceSelect />
-          <TokenSelect />
-          <AmountInput />
-          <SubmitButton />
-        </FormControllerStyled>
-        <ClaimBondFormInfo />
+        <BaseFormLoader>
+          <FormControllerStyled>
+            <SourceSelect />
+            <TokenSelect />
+            <AmountInput />
+            <SubmitButton />
+          </FormControllerStyled>
+          <ClaimBondFormInfo />
+        </BaseFormLoader>
       </FormBlock>
     </ClaimBondFormProvider>
   );

--- a/features/claim-bond/claim-bond-form/context/claim-bond-form-provider.tsx
+++ b/features/claim-bond/claim-bond-form/context/claim-bond-form-provider.tsx
@@ -1,18 +1,18 @@
 import { FC, PropsWithChildren, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { TOKENS } from 'consts/tokens';
 import {
   FormControllerContext,
   FormControllerContextValueType,
   FormDataContext,
+  useFormControllerRetry,
   useFormData,
 } from 'shared/hook-form/form-controller';
-import { useFormControllerRetry } from 'shared/hook-form/form-controller';
+import { ClaimBondFormNetworkData, type ClaimBondFormInputType } from './types';
 import { useClaimBondFormNetworkData } from './use-claim-bond-form-network-data';
 import { useClaimBondSubmit } from './use-claim-bond-submit';
-import { ClaimBondFormNetworkData, type ClaimBondFormInputType } from './types';
-import { useFormRevalidate } from './use-form-revalidate';
 import { useClaimBondValidation } from './use-claim-bond-validation';
+import { useFormRevalidate } from './use-form-revalidate';
+import { useGetDefaultValues } from './use-get-default-values';
 
 export const useClaimBondFormData = useFormData<ClaimBondFormNetworkData>;
 
@@ -20,13 +20,10 @@ export const ClaimBondFormProvider: FC<PropsWithChildren> = ({ children }) => {
   const [networkData, revalidate] = useClaimBondFormNetworkData();
   const validationResolver = useClaimBondValidation(networkData);
 
-  // TODO: default claimRewards=true only if rewards > 0
+  const asyncDefaultValues = useGetDefaultValues(networkData);
+
   const formObject = useForm<ClaimBondFormInputType>({
-    defaultValues: {
-      token: TOKENS.STETH,
-      amount: undefined,
-      claimRewards: true,
-    },
+    defaultValues: asyncDefaultValues,
     resolver: validationResolver,
     mode: 'onChange',
   });

--- a/features/claim-bond/claim-bond-form/context/use-claim-bond-submit.ts
+++ b/features/claim-bond/claim-bond-form/context/use-claim-bond-submit.ts
@@ -100,9 +100,6 @@ export const useClaimBondSubmit = ({
     ): Promise<boolean> => {
       invariant(token, 'Token is not defined');
       invariant(nodeOperatorId, 'NodeOperatorId is not defined');
-      if (claimRewards) {
-        invariant(rewards, 'Rewards proof is not defined');
-      }
 
       try {
         txModalStages.sign({ amount, token });

--- a/features/claim-bond/claim-bond-form/context/use-claim-bond-validation.ts
+++ b/features/claim-bond/claim-bond-form/context/use-claim-bond-validation.ts
@@ -18,10 +18,15 @@ export const useClaimBondValidation = (
     async (values, _, options) => {
       try {
         const { token, amount, claimRewards } = values;
-        const { maxValues } = await contextPromise;
+        const { maxValues, rewards } = await contextPromise;
 
-        if (options.names?.includes('amount') && amount?.gt(0)) {
-          validateEtherAmount('amount', amount, token);
+        if (options.names?.includes('amount')) {
+          validateEtherAmount(
+            'amount',
+            amount,
+            token,
+            claimRewards && rewards?.available.gt(0),
+          );
 
           const maxAmount = maxValues?.[token][Number(claimRewards)];
           if (amount && maxAmount)

--- a/features/claim-bond/claim-bond-form/context/use-get-default-values.ts
+++ b/features/claim-bond/claim-bond-form/context/use-get-default-values.ts
@@ -1,0 +1,22 @@
+import { TOKENS } from 'consts/tokens';
+import { useMemo } from 'react';
+import { useDefaultValues } from 'shared/hooks';
+import { ClaimBondFormInputType, ClaimBondFormNetworkData } from './types';
+
+export const useGetDefaultValues = ({
+  rewards,
+  loading,
+}: ClaimBondFormNetworkData) => {
+  return useDefaultValues<ClaimBondFormInputType>(
+    useMemo(() => {
+      if (Object.values(loading).some(Boolean)) {
+        return undefined;
+      }
+
+      return {
+        token: TOKENS.STETH,
+        claimRewards: rewards?.available.gt(0) ?? false,
+      };
+    }, [loading, rewards?.available]),
+  );
+};

--- a/features/claim-bond/claim-bond-form/controls/source-select.tsx
+++ b/features/claim-bond/claim-bond-form/controls/source-select.tsx
@@ -51,6 +51,7 @@ export const SourceSelect: FC = () => {
               {...field}
               value=""
               checked={!!field.value}
+              disabled={!rewards?.available.gt(0)}
             />
           }
           help="The rewards amount available to claim, obtained from all active validators of the Node Operator"

--- a/shared/hook-form/validation/validate-ether-amount.ts
+++ b/shared/hook-form/validation/validate-ether-amount.ts
@@ -8,14 +8,23 @@ export const validateEtherAmount = (
   field: string,
   amount: BigNumber | undefined,
   token: TOKENS,
+  allowZero = false,
 ) => {
   if (!amount) throw new ValidationError(field, '');
 
-  if (amount.lte(Zero))
-    throw new ValidationError(
-      field,
-      `Enter ${getTokenDisplayName(token)} ${field} greater than 0`,
-    );
+  if (allowZero) {
+    if (amount.lt(Zero))
+      throw new ValidationError(
+        field,
+        `Enter ${getTokenDisplayName(token)} ${field}`,
+      );
+  } else {
+    if (amount.lte(Zero))
+      throw new ValidationError(
+        field,
+        `Enter ${getTokenDisplayName(token)} ${field} greater than 0`,
+      );
+  }
 
   if (token === TOKENS.ETH && amount.lt(MIN_ETH_AMOUNT))
     throw new ValidationError(


### PR DESCRIPTION
- disable `rewards` if not available
- validation error if `rewards` off & `amount` = 0
- prevent submit form with empty `amount`