### PR TITLE
feat: increase keys limit

### DIFF
--- a/consts/csm-constants.ts
+++ b/consts/csm-constants.ts
@@ -3,6 +3,8 @@ import { config } from 'config';
 import { HexString } from 'shared/keys';
 import { Address } from 'wagmi';
 
+export const KEYS_UPLOAD_TX_LIMIT = 25;
+
 type CsmContract =
   | 'CSAccounting'
   | 'CSEarlyAdoption'
@@ -18,7 +20,6 @@ type CsmConstants = {
   deploymentBlockNumber: HexString;
   stakingModuleId: number;
   withdrawalCredentials: Address;
-  earlyAdoptionMaxKeys: number; // TODO: drop this const
   retentionPeriodMins: number;
 };
 
@@ -37,7 +38,6 @@ export const CONSTANTS_BY_NETWORK: Partial<Record<CHAINS, CsmConstants>> = {
     deploymentBlockNumber: '0x13f7326',
     stakingModuleId: 3,
     withdrawalCredentials: '0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f',
-    earlyAdoptionMaxKeys: 12,
     retentionPeriodMins: 80_640, // 8 weeks
   },
   [CHAINS.Holesky]: {
@@ -54,7 +54,6 @@ export const CONSTANTS_BY_NETWORK: Partial<Record<CHAINS, CsmConstants>> = {
     deploymentBlockNumber: '0x1b143a',
     stakingModuleId: 4,
     withdrawalCredentials: '0xF0179dEC45a37423EAD4FaD5fCb136197872EAd9',
-    earlyAdoptionMaxKeys: 10,
     retentionPeriodMins: 80_640, // 8 weeks
   },
 };

--- a/features/add-keys/add-keys/controls/submit-button.tsx
+++ b/features/add-keys/add-keys/controls/submit-button.tsx
@@ -1,18 +1,17 @@
 import { Note } from 'shared/components';
 import { PausedButton, SubmitButtonHookForm } from 'shared/hook-form/controls';
+import { useKeysTotalLimit } from 'shared/hooks';
 import { useAddKeysFormData } from '../context';
-import { getCsmConstants } from 'consts/csm-constants';
 
 export const SubmitButton = () => {
   const { keysUploadLimit, isPaused } = useAddKeysFormData();
+  const { data: keysTotalLimit } = useKeysTotalLimit();
 
   const keysLimitReached = keysUploadLimit === 0;
 
   if (isPaused) {
     return <PausedButton type="Module" />;
   }
-
-  const MAX_KEYS_TO_UPLOAD = getCsmConstants().earlyAdoptionMaxKeys;
 
   return (
     <>
@@ -22,9 +21,9 @@ export const SubmitButton = () => {
       >
         {keysLimitReached ? 'Keys limit has been reached' : 'Submit keys'}
       </SubmitButtonHookForm>
-      {keysLimitReached && (
+      {keysLimitReached && keysTotalLimit && (
         <Note>
-          You have reached the Early Access upload limit of {MAX_KEYS_TO_UPLOAD}{' '}
+          You have reached the Early Access upload limit of {keysTotalLimit}{' '}
           keys. You cannot upload more.
         </Note>
       )}

--- a/features/dashboard/keys/keys-section.tsx
+++ b/features/dashboard/keys/keys-section.tsx
@@ -4,7 +4,7 @@ import { useNodeOperatorId } from 'providers/node-operator-provider';
 import { FC, useCallback } from 'react';
 import { SectionBlock, Stack, StatusComment } from 'shared/components';
 import {
-  useKeysLimit,
+  useKeysTotalLimit,
   useKeysWithStatus,
   useNodeOperatorInfo,
 } from 'shared/hooks';
@@ -26,7 +26,7 @@ const BAD_STATUSES: KEY_STATUS[] = [
 export const KeysSection: FC = () => {
   const id = useNodeOperatorId();
   const { data: info } = useNodeOperatorInfo(id);
-  const { data: eaTarget } = useKeysLimit();
+  const { data: eaTarget } = useKeysTotalLimit();
 
   const { data: keys } = useKeysWithStatus();
 

--- a/shared/hooks/use-keys-upload-limit.ts
+++ b/shared/hooks/use-keys-upload-limit.ts
@@ -1,4 +1,4 @@
-import { getCsmConstants } from 'consts/csm-constants';
+import { KEYS_UPLOAD_TX_LIMIT } from 'consts/csm-constants';
 import { useNodeOperatorId } from 'providers/node-operator-provider';
 import {
   useCsmEarlyAdoptionKeysLimit,
@@ -11,7 +11,7 @@ import { NodeOperatorId } from 'types';
 /**
  * @note 0 = no limits
  */
-export const useKeysLimit = () => {
+export const useKeysTotalLimit = () => {
   const swrPublicRelease = useCsmPublicRelease();
   const swrEAKeysLimit = useCsmEarlyAdoptionKeysLimit();
 
@@ -35,17 +35,15 @@ export const useNonWithdrawnKeysCount = (nodeOperatorId?: NodeOperatorId) => {
 export const useKeysUploadLimit = () => {
   const nodeOperatorId = useNodeOperatorId();
   const swrUploaded = useNonWithdrawnKeysCount(nodeOperatorId);
-  const swrLimit = useKeysLimit();
-
-  const MAX_KEYS_TO_UPLOAD = getCsmConstants().earlyAdoptionMaxKeys;
+  const swrLimit = useKeysTotalLimit();
 
   return useMergeSwr(
     [swrUploaded, swrLimit],
     swrLimit.data
       ? Math.min(
           Math.max(swrLimit.data - (swrUploaded.data ?? 0), 0),
-          MAX_KEYS_TO_UPLOAD,
+          KEYS_UPLOAD_TX_LIMIT,
         )
-      : MAX_KEYS_TO_UPLOAD,
+      : KEYS_UPLOAD_TX_LIMIT,
   );
 };


### PR DESCRIPTION
## Description

Keys upload limit increased to 25 (for one transaction)
EA still have it's limit (12 for mainnet)

## Related Issue

[CS-595](https://linear.app/lidofi/issue/CS-595/raise-key-upload-limit-to-25-keys)
