### PR TITLE
fix: count of uploaded keys with withdrawn

### DIFF
--- a/shared/hooks/use-keys-upload-limit.ts
+++ b/shared/hooks/use-keys-upload-limit.ts
@@ -32,9 +32,15 @@ export const useNonWithdrawnKeysCount = (nodeOperatorId?: NodeOperatorId) => {
   );
 };
 
+export const useTotalAddedKeysCount = (nodeOperatorId?: NodeOperatorId) => {
+  const swrInfo = useNodeOperatorInfo(nodeOperatorId);
+
+  return useMergeSwr([swrInfo], swrInfo.data?.totalAddedKeys ?? 0);
+};
+
 export const useKeysUploadLimit = () => {
   const nodeOperatorId = useNodeOperatorId();
-  const swrUploaded = useNonWithdrawnKeysCount(nodeOperatorId);
+  const swrUploaded = useTotalAddedKeysCount(nodeOperatorId);
   const swrLimit = useKeysTotalLimit();
 
   return useMergeSwr(


### PR DESCRIPTION
## Description

[CS-614](https://linear.app/lidofi/issue/CS-614/ea-limit-doesnt-count-withdrawn-keys)

EA keys count limit must take into account the withdrawn keys too 
