### PR TITLE
Fix/reset role address

### DIFF
--- a/features/change-role/change-role-form/context/use-change-role-submit.ts
+++ b/features/change-role/change-role-form/context/use-change-role-submit.ts
@@ -98,6 +98,7 @@ export const useChangeRoleSubmit = ({
       {
         nodeOperatorId,
         proposedAddress,
+        currentAddress,
         role,
         isPropose,
         isManagerReset,
@@ -107,6 +108,7 @@ export const useChangeRoleSubmit = ({
       const address = isRevoke ? AddressZero : addressRaw;
       invariant(role, 'Role is not defined');
       invariant(address, 'Addess is not defined');
+      invariant(currentAddress, 'CurrentAddess is not defined');
       invariant(nodeOperatorId, 'NodeOperatorId is not defined');
 
       if (
@@ -130,8 +132,10 @@ export const useChangeRoleSubmit = ({
       try {
         txModalStages.sign({
           address,
+          currentAddress,
           role,
           isPropose,
+          isRevoke,
           isRewardsChange,
           isManagerReset,
         });
@@ -150,7 +154,15 @@ export const useChangeRoleSubmit = ({
         );
 
         txModalStages.pending(
-          { address, role, isPropose, isRewardsChange, isManagerReset },
+          {
+            address,
+            currentAddress,
+            role,
+            isPropose,
+            isRevoke,
+            isRewardsChange,
+            isManagerReset,
+          },
           txHash,
         );
 
@@ -159,7 +171,15 @@ export const useChangeRoleSubmit = ({
         await onConfirm?.();
 
         txModalStages.success(
-          { address, role, isPropose, isRewardsChange, isManagerReset },
+          {
+            address,
+            currentAddress,
+            role,
+            isPropose,
+            isRevoke,
+            isRewardsChange,
+            isManagerReset,
+          },
           txHash,
         );
 

--- a/features/change-role/change-role-form/controls/submit-button.tsx
+++ b/features/change-role/change-role-form/controls/submit-button.tsx
@@ -7,17 +7,23 @@ import { useRole } from '../hooks/use-role';
 
 export const SubmitButton = () => {
   const role = useRole();
-  const { isPropose } = useChangeRoleFormData();
+  const { isPropose, isManagerReset } = useChangeRoleFormData();
   const { setValue } = useFormContext<ChangeRoleFormInputType>();
 
   const clickHandle = useCallback(() => {
     setValue('isRevoke', false);
   }, [setValue]);
 
+  const title = isManagerReset
+    ? `Reset ${role} address`
+    : isPropose
+      ? `Propose a new ${role} address`
+      : `Change ${role} address`;
+
   return (
     <>
       <SubmitButtonHookForm errorField="address" onClick={clickHandle}>
-        {isPropose ? 'Propose a new' : 'Change'} {role} address
+        {title}
       </SubmitButtonHookForm>
       {isPropose && (
         <Note>

--- a/features/change-role/change-role-form/hooks/use-tx-modal-stages-change-role.tsx
+++ b/features/change-role/change-role-form/hooks/use-tx-modal-stages-change-role.tsx
@@ -1,4 +1,5 @@
 import { ROLES } from 'consts/roles';
+import { capitalize } from 'lodash';
 import { getRoleTitle } from 'shared/node-operator';
 import {
   TransactionModalTransitStage,
@@ -11,10 +12,12 @@ import {
 
 type Props = {
   address: string;
+  currentAddress: string;
   role: ROLES;
   isManagerReset: boolean;
   isRewardsChange: boolean;
   isPropose: boolean;
+  isRevoke: boolean;
 };
 
 // TODO: show address with <Address> component
@@ -26,12 +29,22 @@ const getTexts = (props: Props) => {
           description: `New address ${props.address}`,
         },
         success: {
-          title: `${getRoleTitle(props.role)} address has been changed`,
+          title: `${capitalize(getRoleTitle(props.role))} address has been changed`,
           description: `New address ${props.address}`,
         },
       }
-    : props.isPropose
+    : props.isRevoke
       ? {
+          sign: {
+            title: `You are revoking request for ${getRoleTitle(props.role)} address change`,
+            description: `Address stays ${props.currentAddress}`,
+          },
+          success: {
+            title: `Proposed request for ${getRoleTitle(props.role)} address has been revoked`,
+            description: `Address stays ${props.currentAddress}`,
+          },
+        }
+      : {
           sign: {
             title: `You are proposing ${getRoleTitle(props.role)} address change`,
             description: `Proposed address ${props.address}`,
@@ -39,16 +52,6 @@ const getTexts = (props: Props) => {
           success: {
             title: `New ${getRoleTitle(props.role)} address has been proposed`,
             description: `To complete the address change, the owner of the new address must confirm the change`,
-          },
-        }
-      : {
-          sign: {
-            title: `You are revoking request for ${getRoleTitle(props.role)} address change`,
-            description: `Address stays ${props.address}`,
-          },
-          success: {
-            title: `Proposed request for ${getRoleTitle(props.role)} address has been revoked`,
-            description: ``,
           },
         };
 };

--- a/shared/components/input-address/input-address.tsx
+++ b/shared/components/input-address/input-address.tsx
@@ -52,7 +52,11 @@ export const InputAddress = forwardRef<
         }
         rightDecorator={
           rightDecorator ?? (
-            <>{isLocked ? <InputDecoratorLocked /> : undefined}</>
+            <>
+              {isLocked ? (
+                <InputDecoratorLocked title="Allows reset to the current address only" />
+              ) : undefined}
+            </>
           )
         }
         disabled={props.disabled || isLocked}

--- a/shared/components/input-amount/input-decorator-locked/input-decorator-locked.tsx
+++ b/shared/components/input-amount/input-decorator-locked/input-decorator-locked.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react';
-import { LockSmall, Tooltip } from '@lidofinance/lido-ui';
+import { LockSmall, Tooltip, TooltipProps } from '@lidofinance/lido-ui';
 import { LockWrapper } from './styles';
 
-export const InputDecoratorLocked: FC = (props) => (
+export const InputDecoratorLocked: FC<Partial<TooltipProps>> = (props) => (
   <Tooltip
     title="This field is calculated automatically based on the number of keys and the bond curve.  Follow the FAQ section to learn more"
     placement="top"


### PR DESCRIPTION
## Description

- fix locked address tooltip (reset manager role) [CS-592](https://linear.app/lidofi/issue/CS-592/wrong-tooltip-when-reseting-manager-address-from-the-reward-address)
- fix modal text (revoke proposed role change) [CS-575](https://linear.app/lidofi/issue/CS-575/replace-0x0000-with-the-address-we-are-assigning-the-role-to) [CS-594](https://linear.app/lidofi/issue/CS-594/capitalise-first-letters-in-the-pup-up)
- rename Submit button (revoke proposed role change) [CS-592](https://linear.app/lidofi/issue/CS-592/wrong-tooltip-when-reseting-manager-address-from-the-reward-address)