### PR TITLE
fix: link to stake-widget claim

### DIFF
--- a/features/claim-bond/claim-bond-form/hooks/use-tx-modal-stages-claim-bond.tsx
+++ b/features/claim-bond/claim-bond-form/hooks/use-tx-modal-stages-claim-bond.tsx
@@ -68,7 +68,7 @@ const getTxModalStagesClaimBond = (
               Request withdrawal of{' '}
               <TxAmount amount={amount} token={TOKENS.STETH} /> has been sent.
               Check{' '}
-              <MatomoLink href={`${stakeWidget}/claim`}>
+              <MatomoLink href={`${stakeWidget}/withdrawals/claim`}>
                 Claim tab on the Lido Staking Widget
               </MatomoLink>{' '}
               to view your withdrawal requests or view your transaction on{' '}


### PR DESCRIPTION
## Description

- fix link to https://stake.lido.fi/withdrawals/claim
