### PR TITLE
feat: no keys in last reward

### DIFF
--- a/features/dashboard/bond/last-rewards.tsx
+++ b/features/dashboard/bond/last-rewards.tsx
@@ -25,6 +25,7 @@ import { Balance } from './balance';
 import {
   AccordionStyle,
   BadgeStyle,
+  DoubleColumnStyle,
   RowBody,
   RowHeader,
   RowTitle,
@@ -38,7 +39,6 @@ export const LastRewards: FC = () => {
   const { data: info } = useNodeOperatorInfo(id);
 
   const { data: rewardsSlot } = useLastRewardsSlot();
-  const { data: txHash, initialLoading: isTxLoading } = useLastRewrdsTx();
 
   const lastRewardsDate = rewardsSlot?.timestamp
     ? formatDate(rewardsSlot.timestamp)
@@ -85,34 +85,7 @@ export const LastRewards: FC = () => {
       }
     >
       <Stack direction="column" gap="lg">
-        <RowBody>
-          <TextBlock
-            title="Keys over threshold"
-            loading={isLoading}
-            description={
-              <Tooltip title={lastRewards?.threshold} placement="bottomLeft">
-                <span>Threshold: {formatPercent(lastRewards?.threshold)}%</span>
-              </Tooltip>
-            }
-            help="Number of your keys above the performance threshold in the latest report frame"
-          >
-            {lastRewards?.validatorsOverThresholdCount}{' '}
-            <i>/{lastRewards?.validatorsCount}</i>
-          </TextBlock>
-          <TextBlock
-            title="Stuck keys found"
-            loading={isLoading}
-            warning={lastRewards?.stuck}
-            help="Indicates whether any of your Node Operator keys were marked as “Stuck” during the latest report frame. Stuck keys prevent the Node Operator from receiving rewards for any key(s) in that frame."
-          >
-            {lastRewards?.stuck ? 'YES' : 'NO'}
-          </TextBlock>
-          <TextBlock title="Distribution transaction" loading={isTxLoading}>
-            <Box as="span" fontWeight={400}>
-              <TxLinkEtherscan txHash={txHash} />
-            </Box>
-          </TextBlock>
-        </RowBody>
+        <LastReportStats />
         <Divider />
         <Stack spaceBetween center>
           <Stack direction="column" gap="xxs">
@@ -141,6 +114,53 @@ export const LastRewards: FC = () => {
         </Stack>
       </Stack>
     </AccordionStyle>
+  );
+};
+
+const LastReportStats: FC = () => {
+  const { data: lastRewards, initialLoading: isLoading } =
+    useLastOperatorRewards();
+  const { data: txHash, initialLoading: isTxLoading } = useLastRewrdsTx();
+
+  return (
+    <RowBody>
+      {!lastRewards || lastRewards.validatorsCount ? (
+        <>
+          {' '}
+          <TextBlock
+            title="Keys over threshold"
+            loading={isLoading}
+            description={
+              <Tooltip title={lastRewards?.threshold} placement="bottomLeft">
+                <span>Threshold: {formatPercent(lastRewards?.threshold)}%</span>
+              </Tooltip>
+            }
+            help="Number of your keys above the performance threshold in the latest report frame"
+          >
+            {lastRewards?.validatorsOverThresholdCount}{' '}
+            <i>/{lastRewards?.validatorsCount}</i>
+          </TextBlock>
+          <TextBlock
+            title="Stuck keys found"
+            loading={isLoading}
+            warning={lastRewards?.stuck}
+            help="Indicates whether any of your Node Operator keys were marked as “Stuck” during the latest report frame. Stuck keys prevent the Node Operator from receiving rewards for any key(s) in that frame."
+          >
+            {lastRewards?.stuck ? 'YES' : 'NO'}
+          </TextBlock>
+        </>
+      ) : (
+        <DoubleColumnStyle>
+          <TextBlock title="You had no active keys during the latest rewards frame" />
+        </DoubleColumnStyle>
+      )}
+
+      <TextBlock title="Distribution transaction" loading={isTxLoading}>
+        <Box as="span" fontWeight={400}>
+          <TxLinkEtherscan txHash={txHash} />
+        </Box>
+      </TextBlock>
+    </RowBody>
   );
 };
 

--- a/features/dashboard/bond/styles.ts
+++ b/features/dashboard/bond/styles.ts
@@ -30,6 +30,13 @@ export const RowBody = styled.div`
     grid-template: none;
   }
 `;
+export const DoubleColumnStyle = styled.div`
+  grid-column: span 2;
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    grid-column: initial;
+  }
+`;
 
 export const AccordionStyle = styled(Accordion)`
   margin: 0;


### PR DESCRIPTION
## Description

- state for No keys in last rewards report [CS-667](https://linear.app/lidofi/issue/CS-667/rewards-distribution-section-state-for-nos-with-no-active-keys)

<img width="552" alt="Screenshot 2025-03-11 at 09 02 30" src="https://github.com/user-attachments/assets/63865a52-ad84-4bf9-8cb1-6ad977427f02" />
