### PR TITLE
chore: update titles for Lido operators and fees monitoring links

### DIFF
--- a/features/dashboard/external/external-section.tsx
+++ b/features/dashboard/external/external-section.tsx
@@ -48,7 +48,7 @@ export const ExternalSection: FC = () => {
           Provides effectiveness ratings, APRs and other useful metrics
         </ExternalButtonLink>
         <ExternalButtonLink
-          title="Lido operators"
+          title="Lido Operators"
           icon={<LidoIcon />}
           href={operatorPortalLink}
           matomoEvent={
@@ -58,7 +58,7 @@ export const ExternalSection: FC = () => {
           Shows details about invalid keys
         </ExternalButtonLink>
         <ExternalButtonLink
-          title="Lido MEV monitoring"
+          title="Lido Fees monitoring"
           icon={<LidoIcon />}
           href={feesMonitoningLink}
           matomoEvent={


### PR DESCRIPTION
## Description

- rename Fees monitoring [CS-675](https://linear.app/lidofi/issue/CS-675/lido-mev-monitoring-lido-fees-monitoring)

<img width="543" alt="Screenshot 2025-03-11 at 20 10 42" src="https://github.com/user-attachments/assets/f2955d4d-c1be-4ecd-9183-ce9bb50c2d88" />
