### PR TITLE
feat: surveys cta before april

### DIFF
--- a/features/dashboard/dashboard.tsx
+++ b/features/dashboard/dashboard.tsx
@@ -5,12 +5,14 @@ import { RolesSection } from './roles';
 import { ExternalSection } from './external';
 import { getConfig } from 'config';
 import { CHAINS } from 'consts/chains';
+import { SurveysCta } from './surveys-cta';
 
 const { defaultChain } = getConfig();
 
 export const Dashboard: FC = () => {
   return (
     <>
+      <SurveysCta />
       <KeysSection />
       <BondSection />
       <RolesSection />

--- a/features/dashboard/surveys-cta/index.ts
+++ b/features/dashboard/surveys-cta/index.ts
@@ -1,0 +1,1 @@
+export * from './surveys-cta';

--- a/features/dashboard/surveys-cta/surveys-cta.tsx
+++ b/features/dashboard/surveys-cta/surveys-cta.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+import { Banner } from 'shared/components';
+import { useSurveysCall } from 'shared/hooks';
+import { LocalLink } from 'shared/navigate';
+
+export const SurveysCta: FC = () => {
+  const required = useSurveysCall();
+  if (!required) return null;
+
+  return (
+    <Banner
+      title="Surveys tab is here"
+      href="/surveys"
+      variant="wary-dangerous"
+    >
+      You&apos;re invited to voluntarily submit your validator setup data by
+      March 31st to help enhance the transparency of the Lido Protocol! Go to
+      the <LocalLink href="/surveys">Surveys</LocalLink> tab and fill out the
+      &quot;Your Setup&quot; form.
+    </Banner>
+  );
+};

--- a/shared/components/banner/banner.tsx
+++ b/shared/components/banner/banner.tsx
@@ -1,12 +1,19 @@
-import { FC, PropsWithChildren, ReactNode } from 'react';
+import { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 import {
   BannerContent,
   BannerHeader,
   BannerStyled,
   BannerVariant,
 } from './styles';
+import { LocalLink } from 'shared/navigate';
+import { Stack } from '../stack/stack';
+import { SectionHeaderLinkStyle } from '../section-title/styles';
 
-type BannerProps = {
+import { ReactComponent as RoundedArrowIcon } from 'assets/icons/rounded-arrow.svg';
+
+type BannerProps = Partial<
+  Pick<ComponentProps<typeof LocalLink>, 'href' | 'matomoEvent'>
+> & {
   title?: ReactNode;
   variant?: BannerVariant;
 };
@@ -14,10 +21,18 @@ type BannerProps = {
 export const Banner: FC<PropsWithChildren<BannerProps>> = ({
   title,
   variant,
+  href,
   children,
 }) => (
   <BannerStyled $variant={variant}>
-    <BannerHeader>{title}</BannerHeader>
+    <Stack spaceBetween center>
+      <BannerHeader>{title}</BannerHeader>
+      {!!href && (
+        <SectionHeaderLinkStyle href={href}>
+          <RoundedArrowIcon />
+        </SectionHeaderLinkStyle>
+      )}
+    </Stack>
     <BannerContent>{children}</BannerContent>
   </BannerStyled>
 );

--- a/shared/counters/counter-surveys.tsx
+++ b/shared/counters/counter-surveys.tsx
@@ -1,0 +1,10 @@
+import { FC } from 'react';
+import { Counter } from 'shared/components';
+import { useSurveysCall } from 'shared/hooks';
+
+export const CounterSurveys: FC = () => {
+  const required = useSurveysCall();
+  const count = Number(required);
+
+  return <Counter count={count} />;
+};

--- a/shared/counters/index.ts
+++ b/shared/counters/index.ts
@@ -1,3 +1,4 @@
 export * from './counter-invalid-keys';
 export * from './counter-invites';
 export * from './counter-locked-bond';
+export * from './counter-surveys';

--- a/shared/hooks/index.ts
+++ b/shared/hooks/index.ts
@@ -35,6 +35,7 @@ export * from './use-router-path';
 export * from './use-send-tx';
 export * from './use-show-rule';
 export * from './use-sorted-keys';
+export * from './use-surveys-call';
 export * from './use-token-max-amount';
 export * from './use-tx-cost-in-usd';
 export * from './use-withdrawn-key-indexes-from-events';

--- a/shared/hooks/use-surveys-call.ts
+++ b/shared/hooks/use-surveys-call.ts
@@ -1,0 +1,7 @@
+import { isBefore, parseISO } from 'date-fns';
+
+export const useSurveysCall = () => {
+  const endOfSurvey = parseISO('2025-04-01T00:00Z');
+  const today = new Date();
+  return isBefore(today, endOfSurvey);
+};

--- a/shared/layout/header/components/navigation/use-nav-items.tsx
+++ b/shared/layout/header/components/navigation/use-nav-items.tsx
@@ -12,6 +12,7 @@ import {
   CounterInvalidKeys,
   CounterInvites,
   CounterLockedBond,
+  CounterSurveys,
 } from 'shared/counters';
 import { ShowRule, useShowRule } from 'shared/hooks';
 
@@ -73,6 +74,7 @@ const routes: Route[] = [
     path: PATH.SURVEYS,
     icon: <FileIcon />,
     showRules: ['IS_SURVEYS_ACTIVE'],
+    suffix: <CounterSurveys />,
   },
 ];
 


### PR DESCRIPTION
## Description

- add surveys CTA to dashboard [CS-688](https://linear.app/lidofi/issue/CS-688/add-a-banner-with-cta-to-fill-the-data-on-the-survey-page)

<img width="741" alt="Screenshot 2025-03-25 at 01 22 23" src="https://github.com/user-attachments/assets/e8348297-0658-4c3a-95e9-a1925d95789b" />

