### PR TITLE
fix: last rewards: show zero instead N/A

### DIFF
--- a/features/dashboard/bond/last-rewards.tsx
+++ b/features/dashboard/bond/last-rewards.tsx
@@ -28,6 +28,7 @@ import {
   RowHeader,
   RowTitle,
 } from './styles';
+import { Zero } from '@ethersproject/constants';
 
 export const LastRewards: FC = () => {
   const { data: lastRewards, initialLoading: isLoading } =
@@ -66,7 +67,7 @@ export const LastRewards: FC = () => {
           <Balance
             big
             loading={isLoading || isDistributedLoading}
-            amount={distributed}
+            amount={distributed ?? Zero}
             description={showWhy ? <Why /> : undefined}
           />
         </RowHeader>


### PR DESCRIPTION
## Description

fix: last rewards - show `0` instead `N/A` if NO has no rewards
