### PR TITLE
feat: add smoke tests on preview stand

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,12 +50,26 @@ ETHSEER_API_TOKEN=
 
 # -------- Environment variables for tests --------
 
-# testnet, prod, staging, preview
+# testnet, prod, staging, preview, local
 STAND_TYPE=testnet
 
-# Wallet envs
+# Default wallet with node operator
 WALLET_SECRET_PHRASE=
+# Full empty wallet
+EMPTY_SECRET_PHRASE=
+# Wallet with empty node operator
+EMPTY_NODE_SECRET_PHRASE=
+
 WALLET_PASSWORD=
 
-# DRPC Token
+# DRPC Token. DRPC used as default rpc.
+# If you want using your rpc - just use RPC_URL
 RPC_URL_TOKEN=
+
+# RPC url directly
+RPC_URL=
+
+# All credentianals for run tests on preview stand
+PREVIEW_STAND_URL=
+PREVIEW_STAND_LOGIN=
+PREVIEW_STAND_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ ETHSEER_API_TOKEN=
 # -------- Environment variables for tests --------
 
 # testnet, prod, staging, preview, local
-STAND_TYPE=testnet
+STAND_TYPE=
 
 # Default wallet with node operator
 WALLET_SECRET_PHRASE=

--- a/.github/workflows/ci-preview-deploy.yml
+++ b/.github/workflows/ci-preview-deploy.yml
@@ -73,6 +73,6 @@ jobs:
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:
-      stand_url: ${{ needs.deploy.outputs.stand_url }}
+      preview_stand_url: ${{ needs.deploy.outputs.stand_url }}
       stand_type: 'preview'
       tags: 'smoke'

--- a/.github/workflows/ci-preview-deploy.yml
+++ b/.github/workflows/ci-preview-deploy.yml
@@ -75,4 +75,4 @@ jobs:
     with:
       stand_url: ${{ needs.deploy.outputs.stand_url }}
       stand_type: 'preview'
-      tag: 'smoke'
+      tags: 'smoke'

--- a/.github/workflows/ci-preview-deploy.yml
+++ b/.github/workflows/ci-preview-deploy.yml
@@ -66,3 +66,12 @@ jobs:
         env:
           SHORT_NAME: ${{ steps.repo.outputs.short_name }}
           BRANCH_HASH: ${{ steps.branch.outputs.hash }}
+
+  tests:
+      needs: deploy
+      if: ${{ github.event.pull_request.draft == false }}
+      uses: ./.github/workflows/tests.yml
+      secrets: inherit
+      with:
+        stand_url: ${{ needs.deploy.outputs.stand_url }}
+        stand_type: "preview"

--- a/.github/workflows/ci-preview-deploy.yml
+++ b/.github/workflows/ci-preview-deploy.yml
@@ -68,10 +68,11 @@ jobs:
           BRANCH_HASH: ${{ steps.branch.outputs.hash }}
 
   tests:
-      needs: deploy
-      if: ${{ github.event.pull_request.draft == false }}
-      uses: ./.github/workflows/tests.yml
-      secrets: inherit
-      with:
-        stand_url: ${{ needs.deploy.outputs.stand_url }}
-        stand_type: "preview"
+    needs: deploy
+    if: ${{ github.event.pull_request.draft == false }}
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+    with:
+      stand_url: ${{ needs.deploy.outputs.stand_url }}
+      stand_type: 'preview'
+      tag: 'smoke'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       TEST_BRANCH: ${{ github.event.inputs.branch }}
       DISCORD_REPORT_ENABLED: "${{ github.event_name == 'schedule' && 'true' || 'false' }}"
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL}}
-      DISCORD_DUTY_TAG: '&1227193074044637286'
+      DISCORD_DUTY_TAG: '&1372906915667116032'
 
       # Optional envs
       REFUSE_CF_BLOCK_NAME: ${{ secrets.REFUSE_CF_BLOCK_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # Required envs
-      RPC_URL_TOKEN: ${{ secrets.RPC_URL_TOKEN }}
+      RPC_URL: ${{ secrets.RPC_URL }}
       WALLET_SECRET_PHRASE: ${{ secrets.WALLET_SECRET_PHRASE }}
       WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}
       EMPTY_SECRET_PHRASE: ${{ secrets.EMPTY_SECRET_PHRASE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,21 @@ on:
         options:
           - testnet
           - infra
+  workflow_call:
+    inputs:
+      stand_url:
+        required: true
+        type: string
+        description: Stand url
+      stand_type:
+        description: 'Stand type'
+        required: true
+        type: string
+      tag:
+        required: false
+        type: string
+        default: '-'
+        description: 'Test tags'
 
 jobs:
   test:
@@ -47,7 +62,7 @@ jobs:
       WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}
       EMPTY_SECRET_PHRASE: ${{ secrets.EMPTY_SECRET_PHRASE }}
       EMPTY_NODE_SECRET_PHRASE: ${{ secrets.EMPTY_NODE_SECRET_PHRASE }}
-      
+
       STAND_TYPE: ${{ github.event.inputs.STAND_TYPE || 'testnet' }}
 
       # Common envs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ on:
           - infra
   workflow_call:
     inputs:
-      stand_url:
+      preview_stand_url:
         required: true
         type: string
         description: Stand url
@@ -101,13 +101,13 @@ jobs:
         run: yarn playwright install chromium --with-deps
 
       - name: Set up preview-stand credentials
-        if: ${{ github.event.inputs.stand_type == 'preview' }}
+        if: ${{ inputs.stand_type || github.event.inputs.stand_type == 'preview' }}
         run: |
           if [ -n "${{ github.event.inputs.preview_stand_url }}" ]; then
             echo "Setting login and password for preview stand"
             echo "PREVIEW_STAND_LOGIN=${{ secrets.PREVIEW_STAND_LOGIN }}" >> $GITHUB_ENV
             echo "PREVIEW_STAND_PASSWORD=${{ secrets.PREVIEW_STAND_PASSWORD }}" >> $GITHUB_ENV
-            echo "PREVIEW_STAND_URL=${{ inputs.stand_url || github.event.inputs.preview_stand_url }}" >> $GITHUB_ENV
+            echo "PREVIEW_STAND_URL=${{ inputs.preview_stand_url || github.event.inputs.preview_stand_url }}" >> $GITHUB_ENV
             echo "PREVIEW_STAND_ENV=${{ github.event.inputs.preview_stand_env }}" >> $GITHUB_ENV
           else
             echo "PREVIEW_STAND_URL not provided for preview environment"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Test CSM-widget
-run-name: CSM-widget. Env [${{ github.event.inputs.stand_type || 'testnet' }}]
+run-name: ${{ github.event.action }}. CSM-widget Tests. Env [${{ github.event.inputs.stand_type || 'testnet' }}]
 
 on:
   schedule:
@@ -133,4 +133,4 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 5
+          retention-days: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,9 +101,9 @@ jobs:
         run: yarn playwright install chromium --with-deps
 
       - name: Set up preview-stand credentials
-        if: ${{ inputs.stand_type || github.event.inputs.stand_type == 'preview' }}
+        if: ${{ inputs.stand_type  == 'preview' || github.event.inputs.stand_type == 'preview' }}
         run: |
-          if [ -n "${{ github.event.inputs.preview_stand_url }}" ]; then
+          if [ -n "${{ inputs.preview_stand_url || github.event.inputs.preview_stand_url }}" ]; then
             echo "Setting login and password for preview stand"
             echo "PREVIEW_STAND_LOGIN=${{ secrets.PREVIEW_STAND_LOGIN }}" >> $GITHUB_ENV
             echo "PREVIEW_STAND_PASSWORD=${{ secrets.PREVIEW_STAND_PASSWORD }}" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Test CSM-widget
-run-name: ${{ github.event.action }}. CSM-widget Tests. Env [${{ github.event.inputs.stand_type || 'testnet' }}]
+run-name: ${{ github.event_name }}. CSM-widget Tests. Env [${{ github.event.inputs.stand_type || 'testnet' }}]
 
 on:
   schedule:
@@ -93,6 +93,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Test CSM-widget
-run-name: ${{ github.event_name }}. CSM-widget Tests. Env [${{ github.event.inputs.stand_type || 'testnet' }}]
+run-name: CSM-widget Tests. Env [${{ github.event.inputs.stand_type || 'testnet' }}]
 
 on:
   schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ on:
         description: 'Stand type'
         required: true
         type: string
-      tag:
+      tags:
         required: false
         type: string
         default: '-'
@@ -62,8 +62,7 @@ jobs:
       WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}
       EMPTY_SECRET_PHRASE: ${{ secrets.EMPTY_SECRET_PHRASE }}
       EMPTY_NODE_SECRET_PHRASE: ${{ secrets.EMPTY_NODE_SECRET_PHRASE }}
-
-      STAND_TYPE: ${{ github.event.inputs.STAND_TYPE || 'testnet' }}
+      STAND_TYPE: ${{ inputs.stand_type || github.event.inputs.STAND_TYPE || 'testnet' }}
 
       # Common envs
       QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
@@ -72,7 +71,7 @@ jobs:
       GH_BRANCH_REF_NAME: ${{ github.ref_name }}
       GH_EVENT_NAME: ${{ github.event_name }}
       NODE_OPTIONS: --max-old-space-size=4096
-      TEST_TAGS: ${{ github.event.inputs.tags }}
+      TEST_TAGS: ${{ inputs.tags || github.event.inputs.tags }}
       TEST_BRANCH: ${{ github.event.inputs.branch }}
       DISCORD_REPORT_ENABLED: "${{ github.event_name == 'schedule' && 'true' || 'false' }}"
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL}}
@@ -108,7 +107,7 @@ jobs:
             echo "Setting login and password for preview stand"
             echo "PREVIEW_STAND_LOGIN=${{ secrets.PREVIEW_STAND_LOGIN }}" >> $GITHUB_ENV
             echo "PREVIEW_STAND_PASSWORD=${{ secrets.PREVIEW_STAND_PASSWORD }}" >> $GITHUB_ENV
-            echo "PREVIEW_STAND_URL=${{ github.event.inputs.preview_stand_url }}" >> $GITHUB_ENV
+            echo "PREVIEW_STAND_URL=${{ inputs.stand_url || github.event.inputs.preview_stand_url }}" >> $GITHUB_ENV
             echo "PREVIEW_STAND_ENV=${{ github.event.inputs.preview_stand_env }}" >> $GITHUB_ENV
           else
             echo "PREVIEW_STAND_URL not provided for preview environment"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { widgetFullConfig } from 'tests/config';
 import { getReportConfig } from 'tests/config/report.config';
 import { storageState } from 'tests/config/storageState';
+import { prepareGrep } from 'tests/helpers/tests';
 
 // TODO: move it pls
 export const httpCredentials =
@@ -39,6 +40,7 @@ const config: PlaywrightTestConfig = {
     {
       name: 'widget',
       testDir: './tests',
+      grep: prepareGrep(process.env.TEST_TAGS),
     },
   ],
 };

--- a/tests/config/configs/prod.config.ts
+++ b/tests/config/configs/prod.config.ts
@@ -11,9 +11,7 @@ export class ProdConfig extends BaseConfig {
         chainId: 1,
         tokenSymbol: 'ETH',
         chainName: 'Ethereum Mainnet',
-        rpcUrl:
-          process.env.RPC_URL ||
-          `https://lb.drpc.org/ogrpc?network=ethereum&dkey=${process.env.RPC_URL_TOKEN}`,
+        rpcUrl: process.env.RPC_URL as string,
         scan: 'https://etherscan.io/',
       },
     };

--- a/tests/config/configs/staging.config.ts
+++ b/tests/config/configs/staging.config.ts
@@ -1,21 +1,13 @@
 // StagingConfig.ts
-import { BaseConfig } from './base.config';
+import { ProdConfig } from './prod.config';
 
-export class StagingConfig extends BaseConfig {
+export class StagingConfig extends ProdConfig {
   constructor() {
     super();
     this.standConfig = {
+      ...this.standConfig,
       standType: 'staging',
       standUrl: 'https://csm.infra-staging.org',
-      networkConfig: {
-        chainId: 1,
-        tokenSymbol: 'ETH',
-        chainName: 'Ethereum Mainnet',
-        rpcUrl:
-          process.env.RPC_URL ||
-          `https://lb.drpc.org/ogrpc?network=ethereum&dkey=${process.env.RPC_URL_TOKEN}`,
-        scan: 'https://etherscan.io/',
-      },
     };
   }
 }

--- a/tests/config/configs/testnet.config.ts
+++ b/tests/config/configs/testnet.config.ts
@@ -10,9 +10,7 @@ export class TestnetConfig extends BaseConfig {
         chainId: 560048,
         tokenSymbol: 'ETH',
         chainName: 'Hoodi',
-        rpcUrl:
-          process.env.RPC_URL ||
-          `https://lb.drpc.org/ogrpc?network=hoodi&dkey=${process.env.RPC_URL_TOKEN}`,
+        rpcUrl: process.env.RPC_URL as string,
         scan: 'https://hoodi.etherscan.io/',
       },
     };

--- a/tests/consts/common.const.ts
+++ b/tests/consts/common.const.ts
@@ -6,3 +6,7 @@ export enum TokenSymbol {
 
 export const FIRST_BOND = 2.4;
 export const EXTRA_PER_KEY = 1.3;
+
+export enum Tags {
+  smoke = '@smoke',
+}

--- a/tests/consts/timeouts.ts
+++ b/tests/consts/timeouts.ts
@@ -1,3 +1,4 @@
 export const RPC_WAIT_TIMEOUT = 90000;
 export const STAGE_WAIT_TIMEOUT = { timeout: 300000 };
 export const WALLET_PAGE_TIMEOUT_WAITER = 10000;
+export const PAGE_WAIT_TIMEOUT = 15000;

--- a/tests/helpers/tests.ts
+++ b/tests/helpers/tests.ts
@@ -1,0 +1,26 @@
+export const prepareGrep = (testTag: string | undefined) => {
+  if (!testTag || testTag.trim() === '' || testTag === '-') {
+    return undefined;
+  }
+
+  const tags = testTag.split('|');
+  const includeTags = [];
+  const excludeTags = [];
+
+  for (const tag of tags) {
+    if (tag.startsWith('!')) {
+      // remove '!' for invert tags
+      excludeTags.push(tag.slice(1));
+    } else {
+      includeTags.push(tag);
+    }
+  }
+
+  // create regexp for include and exclude tags
+  const includePattern = includeTags.map((tag) => `(?=.*${tag})`).join('');
+  const excludePattern = excludeTags.map((tag) => `(?!.*${tag})`).join('');
+
+  const fullPattern = new RegExp(`^${excludePattern}${includePattern}.*$`);
+
+  return fullPattern;
+};

--- a/tests/widget/operatorWithValidator/common.spec.ts
+++ b/tests/widget/operatorWithValidator/common.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '../test.fixture';
 import { KeysPage } from 'tests/pages/keys.page';
 import { getRandomKeys } from '../../consts/keys.const';
-import { TokenSymbol } from 'tests/consts/common.const';
+import { Tags, TokenSymbol } from 'tests/consts/common.const';
 import { expect } from '@playwright/test';
 import { trimAddress } from '@lidofinance/address';
 import { qase } from 'playwright-qase-reporter/playwright';
@@ -19,6 +19,7 @@ test.describe('Operator with keys. Common suite.', async () => {
 
   test(
     qase(17, 'Should open transaction page after added 1 key'),
+    { tag: Tags.smoke },
     async ({ widgetService }) => {
       const txPage = await keysPage.submitPage.submitKeys(
         getRandomKeys(),

--- a/tests/widget/operatorWithValidator/emptyNode.spec.ts
+++ b/tests/widget/operatorWithValidator/emptyNode.spec.ts
@@ -2,6 +2,7 @@ import { qase } from 'playwright-qase-reporter/playwright';
 import { expect } from '@playwright/test';
 import { test } from '../test.fixture';
 import { KeysPage } from 'tests/pages/keys.page';
+import { PAGE_WAIT_TIMEOUT } from 'tests/consts/timeouts';
 
 test.use({ secretPhrase: process.env.EMPTY_NODE_SECRET_PHRASE });
 
@@ -34,7 +35,7 @@ test.describe('Operator with validator and without keys.', async () => {
     await keysPage.keysView.open();
     await keysPage.keysView.page
       .getByText('View keys list')
-      .waitFor({ state: 'visible', timeout: 20000 });
+      .waitFor({ state: 'visible', timeout: PAGE_WAIT_TIMEOUT });
     await keysPage.keysView.loader.waitFor({ state: 'hidden' });
     await expect(keysPage.keysView.viewKeysBlock).toContainText(
       'There are no keys to display',

--- a/tests/widget/operatorWithValidator/emptyNode.spec.ts
+++ b/tests/widget/operatorWithValidator/emptyNode.spec.ts
@@ -34,7 +34,7 @@ test.describe('Operator with validator and without keys.', async () => {
     await keysPage.keysView.open();
     await keysPage.keysView.page
       .getByText('View keys list')
-      .waitFor({ state: 'visible' });
+      .waitFor({ state: 'visible', timeout: 20000 });
     await keysPage.keysView.loader.waitFor({ state: 'hidden' });
     await expect(keysPage.keysView.viewKeysBlock).toContainText(
       'There are no keys to display',

--- a/tests/widget/operatorWithoutValidator/common.spec.ts
+++ b/tests/widget/operatorWithoutValidator/common.spec.ts
@@ -2,7 +2,7 @@ import { MainPage } from 'tests/pages/main.page';
 import { test } from '../test.fixture';
 import { KeysPage } from 'tests/pages/keys.page';
 import { getRandomKeys } from '../../consts/keys.const';
-import { TokenSymbol } from 'tests/consts/common.const';
+import { Tags, TokenSymbol } from 'tests/consts/common.const';
 import { expect } from '@playwright/test';
 import { trimAddress } from '@lidofinance/address';
 import { qase } from 'playwright-qase-reporter/playwright';
@@ -21,6 +21,7 @@ test.describe('Operator without keys. Common suite.', async () => {
 
   test(
     qase(47, 'Should open transaction page after added 1 key'),
+    { tag: Tags.smoke },
     async ({ widgetService }) => {
       await mainPage.starterPackSection.createNodeOperatorBtn.click();
       await createKeysPage.createNodeOperatorForm.formBlock.waitFor({


### PR DESCRIPTION
## Description

🚀 What’s in this PR?
- ✅ Added support for marking tests with the smoke tag
- 🧪 Enabled automatic smoke test execution on preview environments
- 🔐 Blocking PR merge until smoke tests pass (run immediately after preview build)
- 🛠 Updated .env.example with new config options
- 🧹 Slightly improved overall test stability
- 🤙 Added cache for dependencies in the test job

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

- [ ] Requires other services change
- [ ] Affects to other services
- [ ] Requires dependency update
- [ ] Automated tests
- [ ] Looks good on large screens
- [ ] Looks good on mobile
