### PR TITLE
chore: enable surveys cta from 23 Jun to 06 Jul

### DIFF
--- a/features/dashboard/surveys-cta/surveys-cta.tsx
+++ b/features/dashboard/surveys-cta/surveys-cta.tsx
@@ -4,18 +4,18 @@ import { useSurveysCall } from 'shared/hooks';
 import { LocalLink } from 'shared/navigate';
 
 export const SurveysCta: FC = () => {
-  const required = useSurveysCall();
-  if (!required) return null;
+  const enabled = useSurveysCall();
+  if (!enabled) return null;
 
   return (
     <Banner
-      title="Surveys tab is here"
+      title="Submit Your Validator Setup"
       href="/surveys"
       variant="wary-dangerous"
     >
-      You&apos;re invited to voluntarily submit your validator setup data by
-      March 31st to help enhance the transparency of the Lido Protocol! Go to
-      the <LocalLink href="/surveys">Surveys</LocalLink> tab and fill out the
+      Please submit your validator setup data by July 6th to help enhance the
+      transparency of the Lido Protocol! Go to the{' '}
+      <LocalLink href="/surveys">Surveys</LocalLink> tab and fill out the
       &quot;Your Setup&quot; form.
     </Banner>
   );

--- a/shared/hooks/use-surveys-call.ts
+++ b/shared/hooks/use-surveys-call.ts
@@ -1,11 +1,16 @@
 import { getConfig } from 'config';
 import { CHAINS } from 'consts/chains';
-import { isBefore, parseISO } from 'date-fns';
+import { isAfter, isBefore, parseISO } from 'date-fns';
 
 const { defaultChain } = getConfig();
 
 export const useSurveysCall = () => {
-  const endOfSurvey = parseISO('2025-04-01T00:00Z');
+  const startOfSurvey = parseISO('2025-06-23T00:00Z');
+  const endOfSurvey = parseISO('2025-07-06T00:00Z');
   const today = new Date();
-  return defaultChain === CHAINS.Mainnet && isBefore(today, endOfSurvey);
+  return (
+    defaultChain === CHAINS.Mainnet &&
+    isAfter(today, startOfSurvey) &&
+    isBefore(today, endOfSurvey)
+  );
 };


### PR DESCRIPTION
## Description

- enable Surveys CTA from 23 Jun till 06 Jul [CS-761](https://linear.app/lidofi/issue/CS-761/add-a-banner-with-cta-to-fill-the-data-on-the-survey-page)

<img width="722" alt="Screenshot 2025-06-18 at 18 05 47" src="https://github.com/user-attachments/assets/8d6056e1-cc63-4a11-a970-bca182619013" />

example on [this stand](https://csm-widget-1bee05042d.branch-preview.org/)