### PR TITLE
Fix/custom address current

### DIFF
--- a/shared/components/input-address/input-address.tsx
+++ b/shared/components/input-address/input-address.tsx
@@ -83,6 +83,13 @@ export const InputAddress = forwardRef<
       [resolveInputValue],
     );
 
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.value = value ?? '';
+      }
+      void resolveInputValue(value ?? '');
+    }, [resolveInputValue, value]);
+
     return (
       <StyledInput
         {...props}


### PR DESCRIPTION
## Description

[CS-785](https://linear.app/lidofi/issue/CS-785/current-button-doesnt-visually-update-address-field-during-node)
- fix click on Current button in custom address field on create NodeOperator