### PR TITLE
chore: claim eth - link to stake widget

### DIFF
--- a/features/claim-bond/claim-bond-form/controls/token-select.tsx
+++ b/features/claim-bond/claim-bond-form/controls/token-select.tsx
@@ -16,6 +16,7 @@ import { TokenButtonsHookForm } from 'shared/hook-form/controls';
 import { LocalLink } from 'shared/navigate';
 import { getTokenDisplayName } from 'utils';
 import { ClaimBondFormInputType, useClaimBondFormData } from '../context';
+import { getExternalLinks } from 'consts/external-links';
 
 export const TokenSelect: React.FC = () => {
   const [token, claimRewards] = useWatch<
@@ -24,6 +25,7 @@ export const TokenSelect: React.FC = () => {
   >({ name: ['token', 'claimRewards'] });
   const { loading, maxValues, isContract, isSplitter } = useClaimBondFormData();
   const isLoading = loading.isBondLoading || loading.isRewardsLoading;
+  const { stakeWidget } = getExternalLinks();
 
   const { field: unlockField } = useController<
     ClaimBondFormInputType,
@@ -57,7 +59,14 @@ export const TokenSelect: React.FC = () => {
                 loading={isLoading}
               />
               <YouWillReceive
-                waitingTime="~ 1-5 days"
+                waitingTime={
+                  <>
+                    Check on{' '}
+                    <MatomoLink href={`${stakeWidget}/withdrawals/request`}>
+                      stake widget
+                    </MatomoLink>
+                  </>
+                }
                 receive="withdrawal NFT"
               />
             </Stack>

--- a/shared/components/you-will-receive/you-will-receive.tsx
+++ b/shared/components/you-will-receive/you-will-receive.tsx
@@ -1,9 +1,9 @@
 import { Text } from '@lidofinance/lido-ui';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { Stack } from 'shared/components';
 
 export const YouWillReceive: FC<{
-  waitingTime: string;
+  waitingTime: ReactNode;
   receive: string;
 }> = ({ waitingTime, receive }) => (
   <Stack direction="column" gap="xs">


### PR DESCRIPTION
## Description

- claim ETH waiting time: instead "1-5 days" - link to stake widget

<img width="566" height="190" alt="Screenshot 2025-08-19 at 17 56 56" src="https://github.com/user-attachments/assets/04399fe2-4f33-4417-9df5-f031a5aa88d7" />
