### PR TITLE
chore: update queue colors

### DIFF
--- a/features/view-keys/deposit-queue/style.ts
+++ b/features/view-keys/deposit-queue/style.ts
@@ -11,19 +11,19 @@ const COLOR_VARIANTS = {
     color: #00a3ff;
   `,
   priority0: css`
-    color: #00d4ff;
+    color: #00cfff;
   `,
   priority1: css`
-    color: #00a3ff;
+    color: #007fff;
   `,
   priority2: css`
-    color: #5e8fff;
+    color: #0046ff;
   `,
   priority3: css`
-    color: #808cff;
+    color: #002db3;
   `,
   priority4: css`
-    color: #a366ff;
+    color: #6e0eff;
   `,
   priority5: css`
     color: #c747ff;
@@ -32,28 +32,28 @@ const COLOR_VARIANTS = {
     color: #81d1ff;
   `,
   priority0OverLimit: css`
-    color: #66e9ff;
+    color: #66e7ff;
   `,
   priority1OverLimit: css`
-    color: #66d1ff;
+    color: #66bfff;
   `,
   priority2OverLimit: css`
-    color: #8eadff;
+    color: #668aff;
   `,
   priority3OverLimit: css`
-    color: #a6aeff;
+    color: #6685cc;
   `,
   priority4OverLimit: css`
-    color: #bf99ff;
+    color: #9966ff;
   `,
   priority5OverLimit: css`
-    color: #d785ff;
+    color: #da85ff;
   `,
   batch: css`
     color: #ffa276;
   `,
   added: css`
-    color: #f17ecb;
+    color: #ff8d47ff;
   `,
   limit: css``,
 } as const;

--- a/tests/mock/queue/test-scenarios.ts
+++ b/tests/mock/queue/test-scenarios.ts
@@ -1400,6 +1400,54 @@ export const testScenarios: TestScenario[] = [
       },
     },
   },
+  {
+    title: '[All Priorities] All Priorities Active - Little Submitted Keys',
+    description:
+      'All priorities (P0-P5) have keys with current operator having few keys at the end',
+    data: {
+      nodeOperatorId: 1,
+      shareLimit: {
+        active: 200,
+        queue: 483, // 80 + 70 + 90 + 60 + 100 + 83 = 483 total (3 extra keys from operator 1)
+        capacity: 1000,
+      },
+      operatorInfo: {
+        depositableValidatorsCount: 3, // Small number of keys
+      },
+      formData: {
+        depositDataLength: 3, // Matching the depositable count
+      },
+      depositQueueBatches: {
+        priorities: [
+          [
+            [2, 50],
+            [3, 30],
+          ], // Priority 0: 80 total, no operator 1
+          [
+            [4, 40],
+            [5, 30],
+          ], // Priority 1: 70 total, no operator 1
+          [
+            [6, 55],
+            [7, 35],
+          ], // Priority 2: 90 total, no operator 1
+          [
+            [8, 35],
+            [9, 25],
+          ], // Priority 3: 60 total, no operator 1
+          [
+            [10, 60],
+            [11, 40],
+          ], // Priority 4: 100 total, no operator 1
+          [
+            [12, 50],
+            [13, 30],
+            [1, 3],
+          ], // Priority 5: 83 total, operator 1 at the end with 3 keys
+        ],
+      },
+    },
+  },
 
   // ========================================
   // GROUP L: REALISTIC EDGE CASES


### PR DESCRIPTION
## Description

- updated colors

before:
<img width="565" height="144" alt="Screenshot 2025-08-19 at 13 04 41" src="https://github.com/user-attachments/assets/6670d594-2945-46ba-8337-add0290e201c" />

after:
<img width="577" height="140" alt="Screenshot 2025-08-22 at 12 21 18" src="https://github.com/user-attachments/assets/7f5950a3-1792-4baf-90b5-2b4bfc0b5a8a" />
