### PR TITLE
Fix/csm v2 fixes

### DIFF
--- a/features/remove-keys/remove-keys/controls/amount-input.tsx
+++ b/features/remove-keys/remove-keys/controls/amount-input.tsx
@@ -1,16 +1,21 @@
 import { TOKENS } from '@lidofinance/lido-csm-sdk';
 import { Text } from '@lidofinance/lido-ui';
 import { DisabledInputAmount, Stack } from 'shared/components';
-import { useRemoveKeysFormData } from '../context';
+import { RemoveKeysFormInputType, useRemoveKeysFormData } from '../context';
+import { useWatch } from 'react-hook-form';
 
 export const AmountInput = () => {
   const { removalFee } = useRemoveKeysFormData();
+
+  const { count } = useWatch<RemoveKeysFormInputType, 'selection'>({
+    name: 'selection',
+  });
 
   return (
     <Stack direction="column" gap="xs">
       <DisabledInputAmount
         isLocked="Key deletion incurs a removal charge, deducted from the node operator's bond. This charge covers the maximum possible operational costs of queue processing."
-        amount={removalFee}
+        amount={(removalFee || 0n) * BigInt(count)}
         token={TOKENS.steth}
         label="Removal fee"
         fullwidth

--- a/features/remove-keys/remove-keys/hooks/useBondBalanceAfterRemoveKeys.ts
+++ b/features/remove-keys/remove-keys/hooks/useBondBalanceAfterRemoveKeys.ts
@@ -16,7 +16,7 @@ export const useBondBalanceAfterRemoveKeys = (count = 0) => {
     curveId,
   });
 
-  const bondAfter = (bond?.current ?? 0n) - (removalFee || 0n);
+  const bondAfter = (bond?.current ?? 0n) - (removalFee || 0n) * BigInt(count);
 
   return useQuery({
     queryKey: [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@lidofinance/api-rpc": "^0.47.0",
     "@lidofinance/eth-api-providers": "^0.47.0",
     "@lidofinance/eth-providers": "^0.47.0",
-    "@lidofinance/lido-csm-sdk": "npm:@exromany/lido-csm-sdk@0.1.12",
+    "@lidofinance/lido-csm-sdk": "npm:@exromany/lido-csm-sdk@0.1.13",
     "@lidofinance/lido-ethereum-sdk": "^4.4.0",
     "@lidofinance/lido-ui": "^3.26.0",
     "@lidofinance/next-api-wrapper": "^0.47.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,10 +3014,10 @@
   resolved "https://registry.yarnpkg.com/@lidofinance/eth-providers/-/eth-providers-0.47.0.tgz#186d6e2695c9470cc171d111dac352da5106e681"
   integrity sha512-dF8eUUnK35CNCVa3Z++INtlxlRlYKGx2//eLz7nyFkqwPoOGI0PmVW0qgGiGY9TrGAqkJuXlERszclH8eunYCw==
 
-"@lidofinance/lido-csm-sdk@npm:@exromany/lido-csm-sdk@0.1.12":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@exromany/lido-csm-sdk/-/lido-csm-sdk-0.1.12.tgz#c46fd578999942d28ceb6f3e7740b33edbf40b19"
-  integrity sha512-g5+LvdvkDBpw9f/2FMld3vdvxEHZdPZEUsIjOKuzvJj6sToaNEtcyRT8rfjnUZjKp9i8iPtUcTfiu5lmrDYJ/Q==
+"@lidofinance/lido-csm-sdk@npm:@exromany/lido-csm-sdk@0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@exromany/lido-csm-sdk/-/lido-csm-sdk-0.1.13.tgz#d405d7fcd61c0cc232c39e112f0cd4dc02110ec8"
+  integrity sha512-qUGDNM/D6TW5BEqWqozNlY6hYalbvUtymZmCH3X0ONxB9vDYFWaj3Jw7Z8tjommLO0Wt+H/da12u3DeiY1zJxQ==
   dependencies:
     "@lidofinance/lido-ethereum-sdk" "^4.4.0"
     "@openzeppelin/merkle-tree" "^1.0.8"
@@ -11351,7 +11351,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11367,15 +11367,6 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.1.2:
   version "5.1.2"
@@ -11462,7 +11453,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11482,13 +11473,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12546,16 +12530,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description

- fix: removal fee [CS-866](https://linear.app/lidofi/issue/CS-866/csm-widget-incorrect-eject-cost-when-removing-few-keys-for-pls)
- fix: cover locked bond [CS-882](https://linear.app/lidofi/issue/CS-882/compensation-el-stealing-goes-to-wrong-contract)
