### PR TITLE
fix: update ics round

### DIFF
--- a/features/ics/form-status/components/status-header.tsx
+++ b/features/ics/form-status/components/status-header.tsx
@@ -1,7 +1,7 @@
 import { Button, Text } from '@lidofinance/lido-ui';
 import { PATH } from 'consts';
 import {
-  ICS_ASSESSED_DATE,
+  ICS_ROUND,
   IcsCommentsDto,
   IcsFormStatus,
   IcsScoresDto,
@@ -154,8 +154,8 @@ const useHint = (
     case status === 'REVIEW':
       return (
         <Text size="xs">
-          The application will be evaluated in {ICS_ASSESSED_DATE}. You cannot
-          change the application while it is being reviewed
+          The application will be evaluated in {ICS_ROUND.assessedDate}. You
+          cannot change the application while it is being reviewed
         </Text>
       );
     case status === 'APPROVED':

--- a/features/ics/round-banner/round-banner.tsx
+++ b/features/ics/round-banner/round-banner.tsx
@@ -2,22 +2,24 @@ import { Text } from '@lidofinance/lido-ui';
 import { FC } from 'react';
 import { StyledBlock } from './styles';
 import { Stack } from 'shared/components';
-import {
-  ICS_ROUND,
-  ICS_ROUND_START_DATE,
-  ICS_ASSESSED_DATE,
-} from '../shared/consts';
+import { ICS_ROUND } from '../shared/consts';
 
 export const RoundBanner: FC = () => (
   <StyledBlock>
     <Stack direction="column">
       <Text size="sm" weight={700}>
-        ICS Application Round #{ICS_ROUND} is ongoing
+        ICS Application Round #{ICS_ROUND.round} is ongoing
       </Text>
       <Text size="xxs">
-        All applications received after {ICS_ROUND_START_DATE} will be evaluated
-        in {ICS_ASSESSED_DATE}. Stay tuned for the announcement of the final
-        date for Application Round #{ICS_ROUND}
+        All applications received after {ICS_ROUND.startDate} will be evaluated
+        in {ICS_ROUND.assessedDate}.
+        {!ICS_ROUND.isPreciseAssessedDate && (
+          <>
+            {' '}
+            Stay tuned for the announcement of the final date for Application
+            Round #{ICS_ROUND.round}
+          </>
+        )}
       </Text>
     </Stack>
   </StyledBlock>

--- a/features/ics/shared/consts.tsx
+++ b/features/ics/shared/consts.tsx
@@ -15,14 +15,14 @@ export const ICS_ROUNDS: IcsRound[] = [
   {
     round: 5,
     start: new Date(`2026-04-14`),
-    assessedDate: `Q3-Q4\u00A02026`,
+    assessedDate: `late Q2, or Q3 2026`,
   },
 ];
 
 const formatIcsRoundDate = (date: Date) => format(date, 'MMMM\u00A0dd, yyyy');
 
 const getCurrentRound = () => {
-  const now = new Date('2077-01-01');
+  const now = new Date();
   const current =
     ICS_ROUNDS.findLast((round) => now >= round.start) ||
     ICS_ROUNDS[ICS_ROUNDS.length - 1];

--- a/features/ics/shared/consts.tsx
+++ b/features/ics/shared/consts.tsx
@@ -1,3 +1,39 @@
-export const ICS_ROUND = 4;
-export const ICS_ROUND_START_DATE = `January\u00A022, 2026`;
-export const ICS_ASSESSED_DATE = `Q1-Q2\u00A02026`;
+import { format } from 'date-fns';
+
+type IcsRound = {
+  round: number;
+  start: Date;
+  assessedDate: string;
+};
+
+export const ICS_ROUNDS: IcsRound[] = [
+  {
+    round: 4,
+    start: new Date(`2026-01-22`),
+    assessedDate: `Q1-Q2\u00A02026`,
+  },
+  {
+    round: 5,
+    start: new Date(`2026-04-14`),
+    assessedDate: `Q3-Q4\u00A02026`,
+  },
+];
+
+const formatIcsRoundDate = (date: Date) => format(date, 'MMMM\u00A0dd, yyyy');
+
+const getCurrentRound = () => {
+  const now = new Date('2077-01-01');
+  const current =
+    ICS_ROUNDS.findLast((round) => now >= round.start) ||
+    ICS_ROUNDS[ICS_ROUNDS.length - 1];
+  const next = ICS_ROUNDS.find(({ round }) => round === current.round + 1);
+
+  return {
+    ...current,
+    startDate: formatIcsRoundDate(current.start),
+    assessedDate: next ? formatIcsRoundDate(next.start) : current.assessedDate,
+    isPreciseAssessedDate: !!next,
+  };
+};
+
+export const ICS_ROUND = getCurrentRound();

--- a/features/ics/shared/score-data.tsx
+++ b/features/ics/shared/score-data.tsx
@@ -108,9 +108,9 @@ export const SCORE_SOURCES: ScoreSource[] = [
           <>
             4 points are assigned in case:
             <br />- Submitted address belongs to a Node Operator that has been
-            active on CSM Testnet for at least 60 days
+            active on CSM Hoodi Testnet for at least 60 days
             <br />- Performance for the Node Operator is above the Performance
-            threshold in several of the latest performance oracle reports.
+            threshold over at least 60 days of activity.
             <br />5 points are assigned in case all the requirements from above
             are met, and the application contains an address that has Circles
             verification


### PR DESCRIPTION
## Description

- automatic switch the ICS round when specified
<img width="611" height="121" alt="Screenshot 2026-04-07 at 09 47 20" src="https://github.com/user-attachments/assets/12f93b33-0df4-4be3-abee-59dc959c41a6" />

<img width="603" height="132" alt="Screenshot 2026-04-07 at 10 51 29" src="https://github.com/user-attachments/assets/38685131-7c00-43e9-8b44-6472dbd296c4" />

---

- update text about CSM testnet participation
<img width="550" height="206" alt="Screenshot 2026-04-07 at 09 50 15" src="https://github.com/user-attachments/assets/3d6f4587-676f-46a5-b41f-c77ece2d7555" />
