### PR TITLE
fix: improve csp

### DIFF
--- a/config/csp/index.ts
+++ b/config/csp/index.ts
@@ -19,17 +19,12 @@ export const contentSecurityPolicy: ContentSecurityPolicyOption = {
   directives: {
     'default-src': ["'self'"],
     styleSrc: ["'self'", "'unsafe-inline'"],
-    fontSrc: ["'self'", 'data:'],
-    imgSrc: [
-      "'self'",
-      'data:',
-      'blob:',
-      'https://*.walletconnect.org',
-      'https://*.walletconnect.com',
-    ],
+    fontSrc: ["'self'", 'data:', 'https://fonts.reown.com'],
+    imgSrc: ["'self'", 'data:', 'blob:'],
     scriptSrc: [
       "'self'",
       "'unsafe-inline'",
+      "'wasm-unsafe-eval'",
       ...(config.developmentMode ? ["'unsafe-eval'"] : []), // for HMR
       ...trustedHosts,
     ],

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "tiny-invariant": "^1.1.0",
     "uuid": "^8.3.2",
     "viem": "2.45.0",
-    "wagmi": "3.4.1"
+    "wagmi": "3.4.1",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.3.1",
@@ -128,8 +129,7 @@
     "typechain": "^8.1.1",
     "typescript": "^5.7.3",
     "url-loader": "^4.1.1",
-    "webpack-preprocessor-loader": "^1.3.0",
-    "zod": "^4.1.12"
+    "webpack-preprocessor-loader": "^1.3.0"
   },
   "resolutions": {
     "postcss": "^8.4.31",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,16 @@
+import 'utils/zod-jitless';
+
+import { ToastContainer } from '@lidofinance/lido-ui';
+import { config, SecretConfigType } from 'config';
+import { withCsp } from 'config/csp';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import 'nprogress/nprogress.css';
-import { memo } from 'react';
-
-import { ToastContainer } from '@lidofinance/lido-ui';
-
-import { config, SecretConfigType } from 'config';
-import { withCsp } from 'config/csp';
 import { Providers } from 'providers';
+import { memo } from 'react';
 import { BackgroundGradient, SecurityStatusBanner } from 'shared/components';
 import { SVGGradientDefs } from 'shared/components/svg-gradient-defs/svg-gradient-defs';
-import { nprogress } from 'utils';
-import { AddressValidationFile } from 'utils';
+import { AddressValidationFile, nprogress } from 'utils';
 
 // Visualize route changes
 nprogress();

--- a/utils/zod-jitless.ts
+++ b/utils/zod-jitless.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+// Prevent Zod v4 JIT compilation that violates CSP script-src.
+// Must be imported before any module that creates Zod schemas.
+z.config({ jitless: true });


### PR DESCRIPTION
## Description

[CS-1057](https://linear.app/lidofi/issue/CS-1057/csp-for-csm-widget)

- zod in `jitless` mode
- added `wasm-unsafe-eval` for BLS signature verification
- updated `font-src` and `img-src`

## Testing

[stand](https://csm-widget-035539fac0.branch-preview.org/) with enabled CSP