### PR TITLE
ci: deploy CSM and CM preview/testnet stands together

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -14,16 +14,30 @@ jobs:
   # test:
   #   ...
 
-  deploy:
+  deploy-csm:
     runs-on: ubuntu-latest
     # needs: test
-    name: Build and deploy
+    name: Build and deploy CSM testnet
     steps:
-      - name: Testnet deploy
+      - name: Testnet deploy (CSM)
         uses: lidofinance/dispatch-workflow@v1
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           TARGET_REPO: "lidofinance/infra-mainnet"
           TARGET_WORKFLOW: "deploy_hoodi_testnet_csm_widget.yaml"
+          TARGET: "develop"
+
+  deploy-cm:
+    runs-on: ubuntu-latest
+    # needs: test
+    name: Build and deploy CM testnet
+    steps:
+      - name: Testnet deploy (CM)
+        uses: lidofinance/dispatch-workflow@v1
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          TARGET_REPO: "lidofinance/infra-mainnet"
+          TARGET_WORKFLOW: "deploy_hoodi_testnet_cm_widget.yaml"
           TARGET: "develop"

--- a/.github/workflows/ci-preview-demolish-cm.yml
+++ b/.github/workflows/ci-preview-demolish-cm.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     types:
       [converted_to_draft, closed]
-    branches:
-      - develop-cm
+    branches-ignore:
+      - main
 
 permissions: {}
 
@@ -23,5 +23,6 @@ jobs:
           TARGET_REPO: "lidofinance/infra-mainnet"
           TARGET: ${{ github.head_ref }}
           TARGET_WORKFLOW: "preview_stand_demolish.yaml"
-          INPUTS_REPO_NAME: "lidofinance/cm-widget"
+          INPUTS_REPO_NAME: ${{ github.repository }}
+          INPUTS_APP_NAME: "cm-widget"
           INPUTS_PR_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci-preview-demolish.yml
+++ b/.github/workflows/ci-preview-demolish.yml
@@ -7,7 +7,6 @@ on:
       [converted_to_draft, closed]
     branches-ignore:
       - main
-      - develop-cm
 
 permissions: {}
 
@@ -25,4 +24,5 @@ jobs:
           TARGET: ${{ github.head_ref }}
           TARGET_WORKFLOW: "preview_stand_demolish.yaml"
           INPUTS_REPO_NAME: ${{ github.repository }}
+          INPUTS_APP_NAME: "csm-widget"
           INPUTS_PR_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci-preview-deploy-cm.yml
+++ b/.github/workflows/ci-preview-deploy-cm.yml
@@ -14,8 +14,8 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - develop-cm
+    branches-ignore:
+      - main
 
 permissions:
   contents: read
@@ -44,12 +44,13 @@ jobs:
           TARGET_REPO: "lidofinance/infra-mainnet"
           TARGET: ${{ github.head_ref || steps.ref.outputs.short_ref }}
           TARGET_WORKFLOW: "preview_stand_deploy.yaml"
-          INPUTS_REPO_NAME: "lidofinance/cm-widget"
+          INPUTS_REPO_NAME: ${{ github.repository }}
+          INPUTS_APP_NAME: "cm-widget"
           INPUTS_PR_ID: ${{ github.event.pull_request.number || steps.pr.outputs.number }}
           INPUTS_INVENTORY: "${{ inputs.inventory || 'testnet' }}"
 
       - name: Define repo short name (CM)
-        run: echo "short_name=$(echo ${{ github.repository }} | cut -d "/" -f 2)" >> $GITHUB_OUTPUT
+        run: echo "short_name=cm-widget" >> $GITHUB_OUTPUT
         id: repo
 
       - name: Define branch hash
@@ -68,7 +69,7 @@ jobs:
 
   tests:
     needs: deploy
-    if: ${{ github.event.pull_request.draft == false  && inputs.inventory == 'testnet'}}
+    if: ${{ github.event.pull_request.draft == false && (!inputs.inventory || inputs.inventory == 'testnet') }}
     uses: ./.github/workflows/tests.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci-preview-deploy.yml
+++ b/.github/workflows/ci-preview-deploy.yml
@@ -16,7 +16,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches-ignore:
       - main
-      - develop-cm
 
 permissions:
   contents: read
@@ -46,6 +45,7 @@ jobs:
           TARGET: ${{ github.head_ref || steps.ref.outputs.short_ref }}
           TARGET_WORKFLOW: "preview_stand_deploy.yaml"
           INPUTS_REPO_NAME: ${{ github.repository }}
+          INPUTS_APP_NAME: "csm-widget"
           INPUTS_PR_ID: ${{ github.event.pull_request.number || steps.pr.outputs.number }}
           INPUTS_INVENTORY: "${{ inputs.inventory || 'testnet' }}"
 


### PR DESCRIPTION
## Summary

- Push to `develop` now deploys both **CSM** and **CM** testnet stands (was: CSM only).
- PR to any branch except `main` now creates **both** CSM and CM preview stands (was: CSM only by default; CM only when targeting `develop-cm`).
- Fixes the CM preview path that previously dispatched against a non-existent `lidofinance/cm-widget` repo.

## Context

`MODULE` env switches the same codebase between CSM and CM. Until now, only the CSM mode produced a preview stand on every PR — CM previews were misconfigured (wrong source repo, missing `MODULE=cm` in compose template, broken trigger filter). This change unifies the path so shared-code regressions can be validated against both modes from a single PR.

## Workflow changes

- `ci-dev.yml` — split into `deploy-csm` + `deploy-cm` jobs; both dispatch on push to `develop`.
- `ci-preview-deploy.yml` / `ci-preview-deploy-cm.yml` — trigger broadened to `branches-ignore: [main]`; pass `INPUTS_APP_NAME` (`csm-widget` / `cm-widget`) so infra-mainnet can deploy both stands without confused-deputy risk; CM workflow now uses real source repo (`github.repository`) instead of the broken hardcoded `lidofinance/cm-widget`; smoke-test condition aligned across both.
- `ci-preview-demolish*.yml` — same trigger + `INPUTS_APP_NAME` updates so cleanup symmetric.

## Dependencies

> ⚠️ **Requires [lidofinance/infra-mainnet#7735](https://github.com/lidofinance/infra-mainnet/pull/7735) to be merged first.**

That PR adds:
- New `app_name` input on `preview_stand_deploy.yaml` / `preview_stand_demolish.yaml` (with allow-list authorization via `preview_stand.source_repo` in per-app config) — referenced by `INPUTS_APP_NAME` here.
- `MODULE=cm` in the preview compose template for CM.
- Build tag fix so CM compose can pull the image.

Without infra-mainnet#7735 merged, this PR's CM preview/testnet deploys will fail at the validator step on the infra-mainnet side.

## Test plan

After infra-mainnet#7735 is merged:
- [ ] Open a draft PR to `develop` from a test branch → mark ready → confirm both `ci-preview-deploy.yml` and `ci-preview-deploy-cm.yml` trigger.
- [ ] Confirm two distinct PR status comments (`csm-widget` and `cm-widget`).
- [ ] Open `csm-widget-<hash>.branch-preview.org` → CSM mode (CSM nav, `IS_CSM` true).
- [ ] Open `cm-widget-<hash>.branch-preview.org` → CM mode (CM nav, gates visible, `IS_CM` true).
- [ ] Close PR → both stands demolished, both comments updated.
- [ ] Push to `develop` → both `deploy_hoodi_testnet_csm_widget.yaml` and `deploy_hoodi_testnet_cm_widget.yaml` runs in infra-mainnet.
- [ ] PR to `main` → no preview stands deployed.