### PR TITLE
ci: add k8s preview-stand workflow (csm + cm)

### DIFF
--- a/.github/actions/delete-harbor-tag/action.yml
+++ b/.github/actions/delete-harbor-tag/action.yml
@@ -1,0 +1,53 @@
+name: Delete Harbor tag
+description: >-
+  Best-effort delete of a PR's image tag from Harbor. A transient failure is
+  surfaced as a warning, never a job failure — the preview stand is already
+  torn down by the descriptor delete, so a lingering tag is storage-only.
+
+inputs:
+  pr:
+    description: PR number (tag is pr-<PR>)
+    required: true
+  registry:
+    description: Harbor registry host
+    required: true
+  repository:
+    description: Harbor project / repository
+    required: true
+  app:
+    description: Image name within the repository
+    required: true
+  registry-user:
+    description: Harbor robot user
+    required: true
+  token:
+    description: Harbor robot token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Delete Harbor tag pr-${{ inputs.pr }} (best-effort)
+      shell: bash
+      env:
+        PR: ${{ inputs.pr }}
+        REGISTRY: ${{ inputs.registry }}
+        REPOSITORY: ${{ inputs.repository }}
+        APP: ${{ inputs.app }}
+        REGISTRY_USER: ${{ inputs.registry-user }}
+        HARBOR_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        URL="https://${REGISTRY}/api/v2.0/projects/${REPOSITORY}/repositories/${APP}/artifacts/pr-${PR}/tags/pr-${PR}"
+        echo "DELETE ${URL}"
+        STATUS=$(curl -sS -o /tmp/harbor-resp -w '%{http_code}' \
+          -X DELETE \
+          -u "${REGISTRY_USER}:${HARBOR_TOKEN}" \
+          -H 'Accept: application/json' \
+          "${URL}" || echo "000")
+        echo "Harbor responded: ${STATUS}"
+        cat /tmp/harbor-resp || true
+        case "${STATUS}" in
+          2*|404) echo "OK (tag deleted or already absent)." ;;
+          *)      echo "::warning::Harbor returned ${STATUS} — descriptor cleanup already pushed, tag deletion deferred." ;;
+        esac

--- a/.github/actions/sync-preview-descriptors/action.yml
+++ b/.github/actions/sync-preview-descriptors/action.yml
@@ -1,0 +1,147 @@
+name: Sync preview descriptors
+description: >-
+  Check out the helm-charts preview branch, add (publish) or remove (cleanup)
+  the csm-widget + cm-widget preview descriptors for a PR, then commit & push.
+
+inputs:
+  mode:
+    description: publish | cleanup
+    required: true
+  pr:
+    description: PR number
+    required: true
+  token:
+    description: Token with write access to the preview repo
+    required: true
+  preview-repo:
+    description: owner/name of the helm-charts preview repo
+    required: true
+  preview-branch:
+    description: Branch holding the preview descriptors
+    required: true
+  preview-dir:
+    description: Directory (within the preview repo) holding descriptors
+    required: true
+  image-name:
+    description: Fully-qualified image name written into imageNameValue (publish only)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # publish always proceeds (a missing branch is a setup error → checkout fails loudly).
+    # cleanup probes first: a PR closed after the branch is gone must skip, not fail red.
+    - name: Resolve whether to proceed
+      id: gate
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        TOKEN: ${{ inputs.token }}
+        REPO: ${{ inputs.preview-repo }}
+        BRANCH: ${{ inputs.preview-branch }}
+      run: |
+        set -euo pipefail
+        if [ "$MODE" = "cleanup" ]; then
+          # Token passed via header, never in the URL/argv (matches the push step).
+          AUTH_HEADER=$(printf 'Authorization: token %s' "${TOKEN}")
+          REMOTE="https://github.com/${REPO}.git"
+          if git -c http.extraheader="${AUTH_HEADER}" ls-remote --exit-code --heads "$REMOTE" "$BRANCH" >/dev/null 2>&1; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::preview branch absent on ${REPO} — skipping descriptor cleanup."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Checkout preview branch
+      if: steps.gate.outputs.proceed == 'true'
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.preview-repo }}
+        ref: ${{ inputs.preview-branch }}
+        token: ${{ inputs.token }}
+        persist-credentials: false
+        path: helm-charts-csm
+
+    - name: Write descriptors
+      if: steps.gate.outputs.proceed == 'true' && inputs.mode == 'publish'
+      working-directory: helm-charts-csm
+      shell: bash
+      env:
+        PR: ${{ inputs.pr }}
+        PREVIEW_DIR: ${{ inputs.preview-dir }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        PREVIEW_REPO: ${{ inputs.preview-repo }}
+        TEMPLATE: ${{ github.action_path }}/descriptor.tmpl.yaml
+      run: |
+        set -euo pipefail
+        mkdir -p "${PREVIEW_DIR}"
+        export PR IMAGE_NAME REPO_URL="https://github.com/${PREVIEW_REPO}.git"
+        for CHART in csm-widget cm-widget; do
+          # Hostname stem matches prod (csm.dev.k8s-dev.org / cm.dev.k8s-dev.org).
+          export CHART HOST="${CHART%-widget}-pr-${PR}.dev.k8s-dev.org"
+          envsubst '${CHART} ${PR} ${IMAGE_NAME} ${HOST} ${REPO_URL}' \
+            < "${TEMPLATE}" > "${PREVIEW_DIR}/${CHART}-pr-${PR}.yaml"
+        done
+        ls -l "${PREVIEW_DIR}"
+
+    - name: Remove descriptors
+      if: steps.gate.outputs.proceed == 'true' && inputs.mode == 'cleanup'
+      working-directory: helm-charts-csm
+      shell: bash
+      env:
+        PR: ${{ inputs.pr }}
+        PREVIEW_DIR: ${{ inputs.preview-dir }}
+      run: |
+        set -euo pipefail
+        for CHART in csm-widget cm-widget; do
+          FILE="${PREVIEW_DIR}/${CHART}-pr-${PR}.yaml"
+          if [ -f "$FILE" ]; then
+            git rm "$FILE"
+          else
+            echo "No descriptor at $FILE — skipping."
+          fi
+        done
+
+    - name: Commit & push
+      if: steps.gate.outputs.proceed == 'true'
+      working-directory: helm-charts-csm
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        PR: ${{ inputs.pr }}
+        TOKEN: ${{ inputs.token }}
+        BRANCH: ${{ inputs.preview-branch }}
+      run: |
+        set -euo pipefail
+        git config user.name  "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "Descriptors already up to date — nothing to commit."
+          exit 0
+        fi
+        if [ "$MODE" = "publish" ]; then
+          MSG="preview: add csm-widget + cm-widget descriptors for PR #${PR}"
+        else
+          MSG="preview: remove csm-widget + cm-widget descriptors for PR #${PR}"
+        fi
+        git commit -m "$MSG"
+        # Token passed only at push time, never written to .git/config.
+        AUTH_HEADER=$(printf 'Authorization: token %s' "${TOKEN}")
+        # Concurrent writers race the branch tip. Each PR touches disjoint files
+        # (${CHART}-pr-${PR}.yaml), so a rejected push rebases cleanly and retries.
+        for attempt in 1 2 3 4 5; do
+          if git -c http.extraheader="${AUTH_HEADER}" push origin "HEAD:${BRANCH}"; then
+            exit 0
+          fi
+          echo "::warning::push rejected (attempt ${attempt}/5) — rebasing on origin/${BRANCH}."
+          git -c http.extraheader="${AUTH_HEADER}" fetch origin "${BRANCH}"
+          git rebase "origin/${BRANCH}"
+          sleep "$((attempt * 2))"
+        done
+        echo "::error::push to ${BRANCH} failed after 5 attempts."
+        exit 1

--- a/.github/actions/sync-preview-descriptors/descriptor.tmpl.yaml
+++ b/.github/actions/sync-preview-descriptors/descriptor.tmpl.yaml
@@ -1,0 +1,10 @@
+# Preview descriptor template. Rendered per-chart by action.yml via envsubst.
+# Substituted vars: CHART, PR, IMAGE_NAME, HOST, REPO_URL. Anything else is left literal.
+name: "${CHART}-preview-${PR}"
+repoURL: "${REPO_URL}"
+revision: "preview"
+chartPath: "${CHART}"
+imageParameter: "overrides.containers[0].image.tag"
+imageValue: "pr-${PR}"
+imageNameValue: "${IMAGE_NAME}"
+ingressHost: "${HOST}"

--- a/.github/actions/upsert-preview-comment/action.yml
+++ b/.github/actions/upsert-preview-comment/action.yml
@@ -1,0 +1,49 @@
+name: Upsert preview comment
+description: >-
+  Create or update a single sticky PR comment (matched by a hidden marker) with
+  the given body. Uses the gh CLI only — no third-party actions.
+
+inputs:
+  pr:
+    description: PR number to comment on
+    required: true
+  token:
+    description: Token with pull-requests:write (usually github.token)
+    required: true
+  repo:
+    description: owner/name of the repo holding the PR
+    required: false
+    default: ${{ github.repository }}
+  body:
+    description: Markdown body (the marker is prepended automatically)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Upsert sticky comment
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR: ${{ inputs.pr }}
+        REPO: ${{ inputs.repo }}
+        BODY: ${{ inputs.body }}
+      run: |
+        set -euo pipefail
+        # Hidden HTML marker identifies *our* comment so repeated runs update in
+        # place instead of appending a new comment on every push.
+        MARKER='<!-- preview-stand-comment -->'
+        FILE="$(mktemp)"
+        { printf '%s\n\n' "$MARKER"; printf '%s\n' "$BODY"; } > "$FILE"
+
+        # First comment carrying the marker wins; --paginate covers busy threads.
+        ID=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+          --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -n1)
+
+        if [ -n "$ID" ]; then
+          gh api "repos/${REPO}/issues/comments/${ID}" -X PATCH -F body=@"$FILE" >/dev/null
+          echo "Updated comment ${ID}."
+        else
+          gh api "repos/${REPO}/issues/${PR}/comments" -F body=@"$FILE" >/dev/null
+          echo "Created new comment."
+        fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,205 @@
+name: Preview stand
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to simulate (must be numeric)
+        required: true
+        type: string
+
+# One group per PR across every event (open/sync/close). cancel-in-progress means a `closed`
+# event cancels its own in-flight build/publish before cleanup runs — so cleanup never races a
+# half-finished push and can't leave orphaned descriptors or Harbor tags. A re-open likewise
+# cancels an in-flight cleanup, then republishes from scratch (publish runs on reopen).
+concurrency:
+  group: preview-${{ github.event.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: harbor.dev.k8s-dev.org
+  REPOSITORY: team-csm
+  APP: csm-widget
+  # Quoted so the literal $ survives shell expansion in any downstream `run:` step.
+  REGISTRY_USER: 'robot$team-csm-rw'
+  PREVIEW_REPO: lidofinance/helm-charts-csm
+  PREVIEW_BRANCH: preview
+  PREVIEW_DIR: previews
+
+jobs:
+  build:
+    name: Build & push :pr-${{ github.event.number || inputs.pr_number }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action != 'closed' &&
+       github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    env:
+      PR: ${{ github.event.number || inputs.pr_number }}
+    steps:
+      # Reject non-numeric workflow_dispatch input early. PR-event payloads are always numeric.
+      - name: Validate PR number
+        run: |
+          set -euo pipefail
+          case "${PR}" in
+            ''|*[!0-9]*) echo "::error::PR must be a positive integer (got '${PR}')." ; exit 1 ;;
+          esac
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Generate build-info.json
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          printf '{"version":"%s:%s"}\n' "$BRANCH" "$COMMIT" > build-info.json
+          cat build-info.json
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
+
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+
+      - name: Build and push :pr-${{ env.PR }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.APP }}:pr-${{ env.PR }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  comment:
+    name: Comment preview URLs
+    needs: build
+    # PR events only (workflow_dispatch has no real PR to comment on), never on close.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR: ${{ github.event.number }}
+      SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout widget repo (for local action)
+        uses: actions/checkout@v4
+
+      - name: Post preview URLs
+        uses: ./.github/actions/upsert-preview-comment
+        with:
+          pr: ${{ env.PR }}
+          token: ${{ github.token }}
+          # Hosts are deterministic: ${CHART%-widget}-pr-${PR}.dev.k8s-dev.org
+          # (see sync-preview-descriptors/action.yml). No need to read them back.
+          body: |
+            ### 🚀 Preview stands
+
+            | Module | URL |
+            | --- | --- |
+            | CSM | https://csm-pr-${{ env.PR }}.dev.k8s-dev.org |
+            | CM | https://cm-pr-${{ env.PR }}.dev.k8s-dev.org |
+
+            Built from `${{ env.SHA }}`. Updated on every push to this PR.
+
+  publish-descriptors:
+    name: Publish csm + cm preview descriptors
+    needs: build
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' ||
+       github.event.action == 'reopened' ||
+       github.event.action == 'ready_for_review') &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      # Local composite action lives in this repo — check it out before `uses: ./...`.
+      # HARDENING (future): this default checkout resolves to the PR merge ref, so the
+      # action code below is PR-modifiable yet runs with HELM_CHARTS_TOKEN (cross-repo
+      # write). Safe for forks (token absent), but a same-repo PR could edit the action
+      # to exfiltrate the token. Pin to the base/default branch — e.g.
+      #   with: { ref: ${{ github.event.pull_request.base.sha }} } — so only trusted
+      # action code runs with the token. The build job must stay on PR head (it builds
+      # the image) but holds only the narrower Harbor token.
+      - name: Checkout widget repo (for local action)
+        uses: actions/checkout@v4
+
+      - name: Publish descriptors
+        uses: ./.github/actions/sync-preview-descriptors
+        with:
+          mode: publish
+          pr: ${{ github.event.number }}
+          token: ${{ secrets.HELM_CHARTS_TOKEN }}
+          preview-repo: ${{ env.PREVIEW_REPO }}
+          preview-branch: ${{ env.PREVIEW_BRANCH }}
+          preview-dir: ${{ env.PREVIEW_DIR }}
+          image-name: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.APP }}
+
+  cleanup:
+    name: Cleanup preview stands
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR: ${{ github.event.number }}
+    steps:
+      # Local composite action lives in this repo — check it out before `uses: ./...`.
+      # HARDENING (future): like publish-descriptors, this runs PR-modifiable action
+      # code with HELM_CHARTS_TOKEN. Pin to the base/default branch — e.g.
+      #   with: { ref: ${{ github.event.pull_request.base.sha }} } — to close the
+      # same-repo token-exfil path.
+      - name: Checkout widget repo (for local action)
+        uses: actions/checkout@v4
+
+      - name: Remove descriptors
+        uses: ./.github/actions/sync-preview-descriptors
+        with:
+          mode: cleanup
+          pr: ${{ env.PR }}
+          token: ${{ secrets.HELM_CHARTS_TOKEN }}
+          preview-repo: ${{ env.PREVIEW_REPO }}
+          preview-branch: ${{ env.PREVIEW_BRANCH }}
+          preview-dir: ${{ env.PREVIEW_DIR }}
+
+      - name: Delete Harbor tag
+        uses: ./.github/actions/delete-harbor-tag
+        with:
+          pr: ${{ env.PR }}
+          registry: ${{ env.REGISTRY }}
+          repository: ${{ env.REPOSITORY }}
+          app: ${{ env.APP }}
+          registry-user: ${{ env.REGISTRY_USER }}
+          token: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+
+      # Mark the sticky comment as torn down rather than deleting it (keeps thread history).
+      - name: Mark preview as removed
+        if: always()
+        uses: ./.github/actions/upsert-preview-comment
+        with:
+          pr: ${{ env.PR }}
+          token: ${{ github.token }}
+          body: |
+            ### 🧹 Preview stands removed
+
+            The CSM & CM preview stands for this PR were torn down when it closed.


### PR DESCRIPTION
## Summary

One PR → one Harbor image (`:pr-<N>`) → two ArgoCD stands (`csm-pr-<N>.dev.k8s-dev.org`, `cm-pr-<N>.dev.k8s-dev.org`). Descriptors land on `helm-charts-csm@preview` where a team `ApplicationSet` (k8s-infra-side) materializes them into `team-csm-previews` namespace. On synchronize the descriptors don't change — ArgoCD Image Updater rolls both deployments off the new digest of the same tag. On close the workflow removes both descriptors and best-effort deletes the Harbor tag.

Implements the [Preview Stands for Product Teams](https://github.com/lidofinance/helm-charts-csm/blob/main/docs/Kubernetes%20adoption%20project/K8s%20roadmap/) RFC on the app-repo side. Pairs with `helm-charts-csm@preview` (separate branch on that repo).

## Why two charts off one image

`cm-widget` chart deploys the **same** csm-widget image with `MODULE=cm`. So a single `docker build` produces one Harbor tag that both Helm releases consume; the workflow writes two descriptors that differ only in `chartPath`, `name`, and `ingressHost`. Hostname stem matches the existing prod convention (`csm.dev.k8s-dev.org` / `cm.dev.k8s-dev.org`).

## Lifecycle

| PR event | Build | Descriptors | Harbor |
|---|---|---|---|
| `opened` / `reopened` | yes | write 2 | tag pushed |
| `synchronize` | yes (same tag, new digest) | no change | digest updated |
| `closed` (merged or not) | — | rm 2 | tag deleted (best-effort) |

## Security posture

- attacker-controlled `head.ref` routed through `env:` (no shell interpolation injection)
- `HELM_CHARTS_TOKEN` never persisted to `.git/config` (push via `http.extraheader`)
- `'robot$team-csm-rw'` quoted so the literal `$` survives any later shell context
- `workflow_dispatch` `pr_number` gated to `^[0-9]+$` before reaching the image tag
- top-level `permissions: contents: read` — no cross-write elevation

## Cleanup posture

- `preview` branch missing → `::warning::` + skip descriptor delete, do not fail
- Harbor non-2xx/404 → `::warning::` + exit 0 (stand already torn down by descriptor delete, tag is just storage)
- concurrency group split by phase so a `closed` event can never cancel an in-flight build

## Prerequisites before this can actually deploy

1. **`HELM_CHARTS_TOKEN`** repo secret created — fine-grained PAT, `contents: write` scoped to `lidofinance/helm-charts-csm` only.
2. **`helm-charts-csm@preview`** branch pushed to origin (`previews/.gitkeep` + `values-k8s-preview.yaml` for csm-widget and cm-widget; prepared separately).
3. **DevOps flips `preview_stands_enabled: true`** for `team-csm` in `lidofinance/k8s-infra`, which creates the consuming `ApplicationSet`, OpenBao preview role, and namespace.

Without (1) and (2) the workflow hard-fails on the chart-repo checkout. Without (3) descriptors land but nothing reconciles them — harmless dangle.

## Test plan

- [ ] Operator creates `HELM_CHARTS_TOKEN` secret in csm-widget
- [ ] Operator pushes `helm-charts-csm@preview` (already prepared locally)
- [ ] DevOps enables `preview_stands_enabled` for `team-csm`
- [ ] Open a throwaway PR; observe `:pr-<N>` push to Harbor, two descriptors in `helm-charts-csm@preview/previews/`
- [ ] Both `csm-pr-<N>.dev.k8s-dev.org` and `cm-pr-<N>.dev.k8s-dev.org` reachable, return the expected MODULE
- [ ] Push a commit to the PR branch; verify Image Updater rolls both deployments
- [ ] Close the PR; verify both descriptors removed and Harbor tag gone

## Follow-ups (not blockers for this PR)

- SHA-pin third-party actions in a separate hardening pass (matches current repo posture of floating on major tags)
- Optional PR comment with the two preview URLs (would require `pull-requests: write` permission elevation; cost not worth it for dev-only stands)
- Drop legacy `ci-preview-deploy*.yml` / `ci-preview-demolish*.yml` once the k8s path is proven (separate PR after first successful end-to-end run)