### PR TITLE
feat(ics): SSV VO in Humanity, broaden High Signal, schedule round 6

### DIFF
--- a/features/dvt/apply-form/controls/main-address-tooltip-content.tsx
+++ b/features/dvt/apply-form/controls/main-address-tooltip-content.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+import styled from 'styled-components';
+
+const TooltipText = styled.div`
+  p + *,
+  li + * {
+    margin-top: ${({ theme }) => theme.spaceMap.xs}px;
+  }
+`;
+
+export const MainAddressTooltipContent: FC = () => (
+  <TooltipText>
+    <p>
+      If your application is approved, this Main address will be able to claim
+      the IDVTC operator type.
+    </p>
+    <p>Choose the Main address based on your setup:</p>
+    <ul>
+      <li>
+        If you are upgrading an existing Node Operator to IDVTC, use the owner
+        address of that Node Operator.
+      </li>
+      <li>
+        If you are creating a new Node Operator, use the address that should
+        claim the IDVTC type. This is usually a multisig controlled by your
+        cluster.
+      </li>
+    </ul>
+  </TooltipText>
+);

--- a/features/dvt/apply-form/controls/main-address.tsx
+++ b/features/dvt/apply-form/controls/main-address.tsx
@@ -1,8 +1,9 @@
 import { Text } from '@lidofinance/lido-ui';
 import { FC } from 'react';
-import { FormTitle, InputAddress, Stack } from 'shared/components';
+import { FormTitle, IconTooltip, InputAddress, Stack } from 'shared/components';
 import { VerifiedChip } from 'shared/components/input-address/verified-chip';
 import { useApplyFormData } from '../context';
+import { MainAddressTooltipContent } from './main-address-tooltip-content';
 
 export const MainAddress: FC = () => {
   const { mainAddress } = useApplyFormData(true);
@@ -13,6 +14,7 @@ export const MainAddress: FC = () => {
         <FormTitle>Main address</FormTitle>
         <Text size="xs" color="secondary">
           You are requesting IDVTC operator type for the following address:
+          <IconTooltip inline tooltip={<MainAddressTooltipContent />} />
         </Text>
       </Stack>
       <InputAddress

--- a/features/ics/shared/consts.tsx
+++ b/features/ics/shared/consts.tsx
@@ -15,7 +15,22 @@ export const ICS_ROUNDS: IcsRound[] = [
   {
     round: 5,
     start: new Date(`2026-04-14`),
-    assessedDate: `late Q2, or Q3 2026`,
+    assessedDate: `June\u00A008, 2026`,
+  },
+  {
+    round: 6,
+    start: new Date(`2026-06-08`),
+    assessedDate: `September\u00A007, 2026`,
+  },
+  {
+    round: 7,
+    start: new Date(`2026-09-07`),
+    assessedDate: `December\u00A007, 2026`,
+  },
+  {
+    round: 8,
+    start: new Date(`2026-12-07`),
+    assessedDate: `late Q4 2026, or Q1 2027`,
   },
 ];
 

--- a/features/ics/shared/score-data.tsx
+++ b/features/ics/shared/score-data.tsx
@@ -306,9 +306,16 @@ export const SCORE_SOURCES: ScoreSource[] = [
               href="https://app.highsignal.xyz/p/lido/"
               matomoEvent={MATOMO_CLICK_EVENTS_TYPES.icsHighSignalLink}
             >
-              Lido or SSV High Signal space
-            </MatomoLink>
-            :
+              Lido
+            </MatomoLink>{' '}
+            or{' '}
+            <MatomoLink
+              href="https://app.highsignal.xyz/p/ssv/"
+              matomoEvent={MATOMO_CLICK_EVENTS_TYPES.icsHighSignalLink}
+            >
+              SSV
+            </MatomoLink>{' '}
+            High Signal space:
             <br />- 2 points if 30 ≤ High Signal score ≤ 40
             <br />- 3 points if 40 {'<'} High Signal score ≤ 60
             <br />- 4 points if 60 {'<'} High Signal score ≤ 80

--- a/features/ics/shared/score-data.tsx
+++ b/features/ics/shared/score-data.tsx
@@ -207,6 +207,14 @@ export const SCORE_SOURCES: ScoreSource[] = [
         ),
       },
       {
+        id: 'ssvHumanity',
+        name: 'SSV Verified operators',
+        icon: <IconStyle src={SSVIcon.src} />,
+        points: 3,
+        description:
+          'Submitted address is present in the SSV Verified Operators list and does not belong to a professional operator',
+      },
+      {
         id: 'discord',
         name: 'Discord',
         icon: <IconStyle src={DiscordIcon.src} />,
@@ -288,7 +296,7 @@ export const SCORE_SOURCES: ScoreSource[] = [
       },
       {
         id: 'highSignal',
-        name: 'Lido High Signal score',
+        name: 'High Signal score',
         icon: <IconStyle src={HighSignalIcon.src} />,
         points: '2-5',
         description: (
@@ -298,13 +306,16 @@ export const SCORE_SOURCES: ScoreSource[] = [
               href="https://app.highsignal.xyz/p/lido/"
               matomoEvent={MATOMO_CLICK_EVENTS_TYPES.icsHighSignalLink}
             >
-              Lido High Signal space
+              Lido or SSV High Signal space
             </MatomoLink>
             :
             <br />- 2 points if 30 ≤ High Signal score ≤ 40
             <br />- 3 points if 40 {'<'} High Signal score ≤ 60
             <br />- 4 points if 60 {'<'} High Signal score ≤ 80
             <br />- 5 points if High Signal score {'>'} 80
+            <br />
+            Lido and SSV scores are not added together. The higher score is
+            used.
             <br />
             For more details, follow{' '}
             <MatomoLink

--- a/features/ics/shared/types.ts
+++ b/features/ics/shared/types.ts
@@ -26,6 +26,7 @@ export type IcsScoresDto = {
   sdvtMainnet?: number;
   humanPassport?: number;
   circles?: number;
+  ssvHumanity?: number;
   discord?: number;
   twitter?: number;
   aragonVotes?: number;

--- a/shared/components/icon-tooltip/icon-tooltip.tsx
+++ b/shared/components/icon-tooltip/icon-tooltip.tsx
@@ -1,12 +1,12 @@
 import { Tooltip } from '@lidofinance/lido-ui';
-import { ComponentProps, FC } from 'react';
+import { ComponentProps, FC, ReactNode } from 'react';
 
 import { ReactComponent as InfoIcon } from 'assets/icons/info.svg';
 import { ReactComponent as CalendarIcon } from 'assets/icons/info-calendar.svg';
 import { IconStyle } from './style';
 
 type Props = Omit<ComponentProps<typeof Tooltip>, 'title' | 'children'> & {
-  tooltip?: string;
+  tooltip?: ReactNode;
   type?: 'info' | 'calendar';
   inline?: boolean;
 };

--- a/tests/services/mockResponses/applyApplication.mock.ts
+++ b/tests/services/mockResponses/applyApplication.mock.ts
@@ -31,6 +31,7 @@ type ApplyApplicationMockResponse = {
     sdvtMainnet: number | null;
     humanPassport: number | null;
     circles: number | null;
+    ssvHumanity: number | null;
     discord: number | null;
     twitter: number | null;
     aragonVotes: number | null;
@@ -70,6 +71,7 @@ export const applyApplicationMockResponse: ApplyApplicationMockResponse = {
     sdvtMainnet: null,
     humanPassport: null,
     circles: null,
+    ssvHumanity: null,
     discord: null,
     twitter: null,
     aragonVotes: null,

--- a/tests/widget/operatorWithValidator/operatorType/applyApplication/submit.spec.ts
+++ b/tests/widget/operatorWithValidator/operatorType/applyApplication/submit.spec.ts
@@ -406,7 +406,13 @@ test.describe('Operator with keys. ICS. Apply application. Submit', async () => 
           .getByTestId('scoreItem')
           .all();
 
-        const expectedLabels = ['Human passport', 'Circles', 'Discord', 'X'];
+        const expectedLabels = [
+          'Human passport',
+          'Circles',
+          'SSV Verified operators',
+          'Discord',
+          'X',
+        ];
         expect(scoreItems).toHaveLength(expectedLabels.length);
 
         for (const [i, item] of scoreItems.entries()) {
@@ -472,7 +478,7 @@ test.describe('Operator with keys. ICS. Apply application. Submit', async () => 
           'Participation in Aragon Votes',
           'Participation in Snapshot Votes',
           'Lido Galxe score',
-          'Lido High Signal score',
+          'High Signal score',
           'GitPOAPs',
         ];
         expect(scoreItems).toHaveLength(expectedLabels.length);


### PR DESCRIPTION
## Summary

[CS-1116](https://linear.app/lidofi/issue/CS-1116/additions-to-ics)

- Schedule ICS round 6 starting June 8, 2026 (round 5 assessment dated `June 08, 2026`)
- Add new **SSV Verified operators** row to Proof-of-Humanity (3 pts), backed by new `ssvHumanity` field in `IcsScoresDto`
- Rename Proof-of-Engagement row `Lido High Signal score` → `High Signal score`; copy updated to cover both Lido and SSV High Signal spaces (`Lido and SSV scores are not added together. The higher score is used.`)
- Sync mock response type/defaults and Playwright expected labels

## Test plan

- [ ] Apply page renders Proof-of-Humanity with SSV Verified operators row (3 pts) between Circles and Discord
- [ ] High Signal row title shows `High Signal score`, copy mentions `Lido or SSV High Signal space` and the "higher score is used" note
- [ ] Round 6 appears in scheduled rounds list, starts June 8 2026, with assessment `late Q3, or Q4 2026`
- [ ] Form-status page for an approved application correctly sums Humanity score with the new field
- [ ] Playwright `submit.spec.ts` Humanity and Engagement label assertions pass

---

**Preview stand (staging surveys API):** https://csm-widget-b70496f239.branch-preview.org (branch `feat/surveys-api-stage-mainnet`)
**Review tool:** https://csm-ics-review.up.railway.app