### PR TITLE
feat: siwe nonce handshake for surveys api auth

### DIFF
--- a/shared/siwe/siwe-auth-provider.tsx
+++ b/shared/siwe/siwe-auth-provider.tsx
@@ -13,7 +13,7 @@ import { useSessionStorage } from 'shared/hooks';
 import invariant from 'tiny-invariant';
 import { extractError } from 'utils';
 import { trackMatomoSiweEvent } from 'utils/track-matomo-event';
-import { AuthContextType } from './types';
+import { AuthContextType, SiweNonceResponse } from './types';
 import { useModalStages } from './use-modal-stages';
 import { useSiwe } from './use-siwe';
 import { useAddressValidation } from 'providers/address-validation-provider';
@@ -52,8 +52,23 @@ export const SiweAuthProvider: FC<PropsWithChildren> = ({ children }) => {
 
     modalStages.sign();
 
+    // The backend rejects any SIWE nonce it did not issue, and the nonce is
+    // short-lived (TTL-bound), so fetch a fresh one right before signing.
+    let nonce: string;
     try {
-      const payload = await siwe();
+      const response = await fetch(`${surveyApi}/auth/nonce`);
+      if (!response.ok) {
+        modalStages.failed(await extractError(response));
+        return;
+      }
+      ({ nonce } = (await response.json()) as SiweNonceResponse);
+    } catch (e) {
+      modalStages.failed(e);
+      return;
+    }
+
+    try {
+      const payload = await siwe(nonce);
 
       modalStages.pending();
       const response = await fetch(`${surveyApi}/auth/signin`, {

--- a/shared/siwe/types.ts
+++ b/shared/siwe/types.ts
@@ -8,6 +8,10 @@ export type SiweOptions = {
   statement: string;
 };
 
+export type SiweNonceResponse = {
+  nonce: string;
+};
+
 export type AuthProviderConfig = {
   storageKeyPrefix: string;
   statement: string;

--- a/shared/siwe/use-siwe.ts
+++ b/shared/siwe/use-siwe.ts
@@ -9,6 +9,7 @@ import { SiweOptions } from './types';
 const createSiweMessage = (
   address: string,
   statement: string,
+  nonce: string,
   chainId?: number,
 ) => {
   const scheme = window.location.protocol.slice(0, -1);
@@ -23,6 +24,7 @@ const createSiweMessage = (
     uri,
     version: '1',
     chainId,
+    nonce,
     expirationTime: addDays(new Date(), 1).toISOString(),
   });
   return message.prepareMessage();
@@ -32,13 +34,16 @@ export const useSiwe = ({ statement }: SiweOptions) => {
   const { address, chainId } = useDappStatus();
   const { mutateAsync: signMessageAsync } = useSignMessage();
 
-  return useCallback(async () => {
-    invariant(address, 'Signer is not available');
+  return useCallback(
+    async (nonce: string) => {
+      invariant(address, 'Signer is not available');
 
-    const message = createSiweMessage(address, statement, chainId);
-    const signature = await signMessageAsync({
-      message,
-    });
-    return { signature, message };
-  }, [address, chainId, signMessageAsync, statement]);
+      const message = createSiweMessage(address, statement, nonce, chainId);
+      const signature = await signMessageAsync({
+        message,
+      });
+      return { signature, message };
+    },
+    [address, chainId, signMessageAsync, statement],
+  );
 };


### PR DESCRIPTION
## What

Embed a **server-issued nonce** in the SIWE message before signing in to the surveys API.

Previously `createSiweMessage` omitted `nonce`, so the `siwe` library silently auto-generated a client-side one — useless against replay. The surveys backend has been hardened to **reject any nonce it did not issue**, so sign-in now fetches a fresh, short-lived nonce via `GET /auth/nonce` and embeds it in the signed message.

Adapts develop's `0abb75df` ("feat: siwe nonce handshake for surveys api auth") to this branch's `shared/siwe/` inline-fetch architecture.

## Changes

- **`shared/siwe/types.ts`** — add `SiweNonceResponse = { nonce: string }`.
- **`shared/siwe/use-siwe.ts`** — `createSiweMessage` takes a `nonce` and embeds it in the `SiweMessage`; `useSiwe` callback now accepts `nonce: string`.
- **`shared/siwe/siwe-auth-provider.tsx`** — fetch the nonce right before signing; its own `try/catch → modalStages.failed` (server/network), kept distinct from the wallet-rejection `catch → modalStages.rejected`.

Sign-in flow: `validateAddress` → `sign()` → **fetch nonce** → sign message *with that nonce* → `POST /auth/signin`.

Public `AuthContextType` (`token`/`signIn`/`logout`) is unchanged, so all surveys/ICS/DVT consumers are unaffected.

## Coordination

⚠️ Requires the surveys backend to serve `GET /auth/nonce` and validate the nonce on `/auth/signin`. Once the hardened backend is live, sign-in will break against any API that doesn't yet issue nonces — roll out together.

## Verification

- `yarn lint:fix` — clean
- `yarn types` — no new errors (the only failures are 4 pre-existing Playwright e2e-spec errors, present on the base branch and untouched here)