### PR TITLE
chore: preview stand (do not merge)

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -56,7 +56,7 @@ export default class MyDocument extends Document {
   }
 
   get metaTitle(): string {
-    return 'Community Staking Module | Lido';
+    return 'Community Staking Module || Lido';
   }
 
   get metaDescription(): string {


### PR DESCRIPTION
Draft PR opened solely to spin up a preview/staging environment. **Not for merge.**

Contains a single throwaway diff (`_document.tsx` meta title) to produce a non-empty PR.