### PR TITLE
fix: migrate survey API to lido.tools domains

### DIFF
--- a/consts/external-links.ts
+++ b/consts/external-links.ts
@@ -76,7 +76,7 @@ export const EXTERNAL_LINKS_BY_NETWORK: Record<
     migalabsDashboard: 'https://migalabs.io/entities',
     migalabs: 'https://migalabs.io',
     keysApi: 'https://keys-api.lido.fi',
-    surveyApi: 'https://csm-surveys-api-mainnet.up.railway.app',
+    surveyApi: 'https://csm-survey-api.lido.tools',
   },
   [CHAINS.Hoodi]: {
     rewardsTree:
@@ -92,7 +92,7 @@ export const EXTERNAL_LINKS_BY_NETWORK: Record<
     migalabsDashboard: '',
     migalabs: 'https://migalabs.io',
     keysApi: 'https://keys-api-hoodi.testnet.fi',
-    surveyApi: 'https://csm-surveys-api-testnet.up.railway.app',
+    surveyApi: 'https://csm-survey-api-hoodi.lido.tools',
   },
 };
 

--- a/tests/config/configs/testnet.config.ts
+++ b/tests/config/configs/testnet.config.ts
@@ -23,7 +23,7 @@ export class TestnetConfig extends BaseConfig {
       },
       mockConfig: {
         urls: {
-          csmSurveysApi: 'https://csm-surveys-api-testnet.up.railway.app',
+          csmSurveysApi: 'https://csm-survey-api-hoodi.lido.tools',
         },
       },
       monitoringConfig: {


### PR DESCRIPTION
## Summary

Migrate the CSM survey API endpoints off the temporary Railway hosts onto Lido's own infra/DNS.

| Network | Old | New |
|---|---|---|
| Mainnet | `csm-surveys-api-mainnet.up.railway.app` | `csm-survey-api.lido.tools` |
| Hoodi (testnet) | `csm-surveys-api-testnet.up.railway.app` | `csm-survey-api-hoodi.lido.tools` |

## Changes

- `consts/external-links.ts` — canonical `surveyApi` values per chain, consumed by the surveys/ICS/DVT fetchers via `getExternalLinks(chainId)`.
- `tests/config/configs/testnet.config.ts` — e2e mock-interception URL kept in sync.

## Notes

- New host naming is singular (`survey-api`) vs. the old plural (`surveys-api`). Internal identifiers (`surveyApi` field, `csmSurveysApi` test key) are unchanged — only the URLs.