### PR TITLE
fix: survey API auth (siwe nonce handshake + lido.tools domains)

### DIFF
--- a/consts/external-links.ts
+++ b/consts/external-links.ts
@@ -83,7 +83,7 @@ export const EXTERNAL_LINKS_BY_NETWORK: Record<
     migalabsDashboard: 'https://migalabs.io/entities',
     migalabs: 'https://migalabs.io',
     keysApi: 'https://keys-api.lido.fi',
-    surveyApi: 'https://csm-surveys-api-mainnet.up.railway.app',
+    surveyApi: 'https://csm-survey-api.lido.tools',
   },
   [CHAINS.Hoodi]: {
     rewardsTree:
@@ -101,7 +101,7 @@ export const EXTERNAL_LINKS_BY_NETWORK: Record<
     migalabsDashboard: '',
     migalabs: 'https://migalabs.io',
     keysApi: 'https://keys-api-hoodi.testnet.fi',
-    surveyApi: 'https://csm-surveys-api-testnet.up.railway.app',
+    surveyApi: 'https://csm-survey-api-hoodi.lido.tools',
   },
 };
 

--- a/shared/siwe/siwe-auth-provider.tsx
+++ b/shared/siwe/siwe-auth-provider.tsx
@@ -13,7 +13,7 @@ import { useSessionStorage } from 'shared/hooks';
 import invariant from 'tiny-invariant';
 import { extractError } from 'utils';
 import { trackMatomoSiweEvent } from 'utils/track-matomo-event';
-import { AuthContextType } from './types';
+import { AuthContextType, SiweNonceResponse } from './types';
 import { useModalStages } from './use-modal-stages';
 import { useSiwe } from './use-siwe';
 import { useAddressValidation } from 'providers/address-validation-provider';
@@ -58,8 +58,23 @@ export const SiweAuthProvider: FC<PropsWithChildren<SiweAuthProviderProps>> = ({
 
     modalStages.sign();
 
+    // The backend rejects any SIWE nonce it did not issue, and the nonce is
+    // short-lived (TTL-bound), so fetch a fresh one right before signing.
+    let nonce: string;
     try {
-      const payload = await siwe();
+      const response = await fetch(`${surveyApi}/auth/nonce`);
+      if (!response.ok) {
+        modalStages.failed(await extractError(response));
+        return;
+      }
+      ({ nonce } = (await response.json()) as SiweNonceResponse);
+    } catch (e) {
+      modalStages.failed(e);
+      return;
+    }
+
+    try {
+      const payload = await siwe(nonce);
 
       modalStages.pending();
       const response = await fetch(`${surveyApi}/auth/signin`, {

--- a/shared/siwe/types.ts
+++ b/shared/siwe/types.ts
@@ -8,6 +8,10 @@ export type SiweOptions = {
   statement: string;
 };
 
+export type SiweNonceResponse = {
+  nonce: string;
+};
+
 export type AuthProviderConfig = {
   storageKeyPrefix: string;
   statement: string;

--- a/shared/siwe/use-siwe.ts
+++ b/shared/siwe/use-siwe.ts
@@ -9,6 +9,7 @@ import { SiweOptions } from './types';
 const createSiweMessage = (
   address: string,
   statement: string,
+  nonce: string,
   chainId?: number,
 ) => {
   const scheme = window.location.protocol.slice(0, -1);
@@ -23,6 +24,7 @@ const createSiweMessage = (
     uri,
     version: '1',
     chainId,
+    nonce,
     expirationTime: addDays(new Date(), 1).toISOString(),
   });
   return message.prepareMessage();
@@ -32,13 +34,16 @@ export const useSiwe = ({ statement }: SiweOptions) => {
   const { address, chainId } = useDappStatus();
   const { mutateAsync: signMessageAsync } = useSignMessage();
 
-  return useCallback(async () => {
-    invariant(address, 'Signer is not available');
+  return useCallback(
+    async (nonce: string) => {
+      invariant(address, 'Signer is not available');
 
-    const message = createSiweMessage(address, statement, chainId);
-    const signature = await signMessageAsync({
-      message,
-    });
-    return { signature, message };
-  }, [address, chainId, signMessageAsync, statement]);
+      const message = createSiweMessage(address, statement, nonce, chainId);
+      const signature = await signMessageAsync({
+        message,
+      });
+      return { signature, message };
+    },
+    [address, chainId, signMessageAsync, statement],
+  );
 };

--- a/tests/csm-widget/config/configs/testnet.config.ts
+++ b/tests/csm-widget/config/configs/testnet.config.ts
@@ -26,7 +26,7 @@ export class TestnetConfig extends BaseConfig {
       },
       mockConfig: {
         urls: {
-          csmSurveysApi: 'https://csm-surveys-api-testnet.up.railway.app',
+          csmSurveysApi: 'https://csm-survey-api-hoodi.lido.tools',
         },
       },
       monitoringConfig: {


### PR DESCRIPTION
Cherry-picks the two most recent change commits from `main` onto `develop`.

## Commits
- `ab69d254` feat: siwe nonce handshake for surveys api auth
- `e395f9b8` fix: migrate survey API to lido.tools domains

Both applied cleanly (auto-merge, no conflicts).