### PR TITLE
Add data-testid and update expected text in tests

### DIFF
--- a/features/add-bond/add-bond-form/controls/info.tsx
+++ b/features/add-bond/add-bond-form/controls/info.tsx
@@ -31,7 +31,7 @@ export const Info: FC = () => {
             data-testid="titledAmount"
           />
           {bond?.isInsufficient ? (
-            <p>
+            <p data-testid="formInfoText">
               Your Node Operator has an Insufficient bond because of the penalty
               applied. Now your Node Operator&apos;s bond is less than required
               to cover the Node Operator&apos;s current validators.
@@ -43,7 +43,7 @@ export const Info: FC = () => {
               unbonded and being requested to exit
             </p>
           ) : (
-            <p>
+            <p data-testid="formInfoText">
               <b>Why you might need to add bond:</b>
               <br />
               Adding a bond serves as a voluntary security measure for your Node

--- a/tests/csm-widget/pages/tabs/bondRewards/addBond.page.ts
+++ b/tests/csm-widget/pages/tabs/bondRewards/addBond.page.ts
@@ -33,7 +33,7 @@ export class AddBondPage extends BasePage {
     this.formInfo = this.form.getByTestId('formInfo');
     this.titledAmount = this.formInfo.getByTestId('titledAmount');
     this.titledAmountBalance = this.titledAmount.locator('div > span');
-    this.formInfoText = this.formInfo.locator('p');
+    this.formInfoText = this.formInfo.getByTestId('formInfoText');
 
     // Enter token amount
     this.amountInput = this.form.locator('input[name="bondAmount"]');

--- a/tests/csm-widget/tests/operatorWithValidator/bondRewards/addBond.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/bondRewards/addBond.spec.ts
@@ -32,7 +32,7 @@ test.describe('Bond & Rewards. Add bond.', async () => {
 
         await test.step('Verify text', async () => {
           const expectedText =
-            'Why you might need to add bond:Adding a bond serves as a voluntary security measure for your Node Operator to prevent your validators from becoming unbonded and being requested to exit in case of applied penalties.Supplied bond will be stored as stETH, which also garners staking rewards.';
+            'Why you might need to add bond:Adding a bond serves as a voluntary security measure for your Node Operator to prevent your validators from becoming unbonded and being requested to exit in case of applied penaltiesSupplied bond will be stored as stETH, which also garners staking rewards';
           await expect(bondRewardsPage.addBond.formInfoText).toContainText(
             expectedText,
           );

--- a/tests/csm-widget/tests/operatorWithValidator/dashboard/roles/common.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/dashboard/roles/common.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '../../../test.fixture';
 import { MatomoService } from 'tests/shared/services/matomo.service';
+import { qase } from 'playwright-qase-reporter/playwright';
 
 test.describe('Dashboard. Roles', async () => {
   let matomoEventService: MatomoService;
@@ -9,18 +10,17 @@ test.describe('Dashboard. Roles', async () => {
     await widgetService.dashboardPage.open();
   });
 
-  test('Should open Roles page after click to section arrow', async ({
-    widgetService,
-  }) => {
-    await Promise.all([
-      matomoEventService.waitForEvent(
-        'e_n',
-        'csm_widget_dashboard_roles_section',
-      ),
-      widgetService.page.waitForURL(
-        /\/roles\/(manager-address|reward-address)$/,
-      ),
-      widgetService.dashboardPage.rolesSection.sectionHeaderLink.click(),
-    ]);
-  });
+  test(
+    qase(140, 'Should open Roles page after click to section arrow'),
+    async ({ widgetService }) => {
+      await Promise.all([
+        matomoEventService.waitForEvent(
+          'e_n',
+          'csm_widget_dashboard_roles_section',
+        ),
+        widgetService.page.waitForURL(/\/settings\/roles$/),
+        widgetService.dashboardPage.rolesSection.sectionHeaderLink.click(),
+      ]);
+    },
+  );
 });

--- a/tests/csm-widget/tests/operatorWithValidator/roles/managerAddress/transactions/reproposed.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/roles/managerAddress/transactions/reproposed.spec.ts
@@ -54,7 +54,7 @@ test.describe(
           );
 
           await expect(settingsPage.modalRoot.paragraphs.first()).toContainText(
-            'When you propose a new address for change - the previous change proposal is voided.',
+            'When you propose a new address for change - the previous change proposal is voided',
           );
 
           await expect(settingsPage.modalRoot.continueButton).toBeVisible();

--- a/tests/csm-widget/tests/operatorWithValidator/roles/rewardsAddress/transactions/reproposed.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/roles/rewardsAddress/transactions/reproposed.spec.ts
@@ -72,7 +72,7 @@ test.describe('Roles. Rewards Address. Transactions. Reproposed Address', () => 
           );
 
           await expect(settingsPage.modalRoot.paragraphs.first()).toContainText(
-            'When you propose a new address for change - the previous change proposal is voided.',
+            'When you propose a new address for change - the previous change proposal is voided',
           );
 
           await expect(settingsPage.modalRoot.continueButton).toBeVisible();


### PR DESCRIPTION
Fixed (test/UI-side changes) - https://app.qase.io/run/CSM/dashboard/1331/64e7456ee7878130e687635809dfbb8c90286579

✅ 140 - Should open Roles page after click to section arrow
✅ 189 - Should display balance and explanatory text for stETH bond
✅ 229 - Should display warning modal after click to repropose button


Reported as bugs (tests not changed): 224, 225 (manager reproposed), 391, 333, 340, 347, 308 (lido-csm-sdk and Invalid deposit data)