### PR TITLE
fix: make terminal tx-modal stages closable on Ledger [stack 2/6]

### DIFF
--- a/features/accept-invite/accept-invite-form/hooks/use-tx-modal-stages-accept-invite.tsx
+++ b/features/accept-invite/accept-invite-form/hooks/use-tx-modal-stages-accept-invite.tsx
@@ -67,9 +67,6 @@ export const buildAcceptInviteStages = (
           </>
         }
       />,
-      {
-        isClosableOnLedger: true,
-      },
     ),
 });
 

--- a/features/add-bond/add-bond-form/hooks/use-tx-modal-stages-add-bond.tsx
+++ b/features/add-bond/add-bond-form/hooks/use-tx-modal-stages-add-bond.tsx
@@ -39,7 +39,6 @@ export const useTxModalStagesAddBond = () =>
             balance={result.current}
             balanceToken={TOKENS.steth}
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/add-keys/add-keys/hooks/use-tx-modal-stages-add-keys.tsx
+++ b/features/add-keys/add-keys/hooks/use-tx-modal-stages-add-keys.tsx
@@ -51,9 +51,6 @@ export const useTxModalStagesAddKeys = () =>
               </>
             }
           />,
-          {
-            isClosableOnLedger: true,
-          },
         ),
     }),
   );

--- a/features/change-role/change-role-form/hooks/use-tx-modal-stages-change-role.tsx
+++ b/features/change-role/change-role-form/hooks/use-tx-modal-stages-change-role.tsx
@@ -132,7 +132,6 @@ export const useTxModalStagesChangeRole = (role: ROLES) => {
               txHash={txHash}
               {...getTexts(input, data, mode).success}
             />,
-            { isClosableOnLedger: true },
           ),
       };
     },

--- a/features/change-role/claimer-form/hooks/use-tx-modal-stages-claimer.tsx
+++ b/features/change-role/claimer-form/hooks/use-tx-modal-stages-claimer.tsx
@@ -62,7 +62,6 @@ export const useTxModalStagesClaimer = () =>
       success: (_result: undefined, txHash) =>
         transitStage(
           <TxStageSuccess txHash={txHash} {...getTexts(input).success} />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/change-role/splits-form/hooks/use-tx-modal-stages-splits.tsx
+++ b/features/change-role/splits-form/hooks/use-tx-modal-stages-splits.tsx
@@ -40,7 +40,6 @@ export const useTxModalStagesSplits = () =>
       success: (_result: undefined, txHash) =>
         transitStage(
           <TxStageSuccess txHash={txHash} {...getTexts(input).success} />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/claim-bond/claim-bond-form/hooks/use-tx-modal-stages-claim-bond.tsx
+++ b/features/claim-bond/claim-bond-form/hooks/use-tx-modal-stages-claim-bond.tsx
@@ -93,9 +93,6 @@ export const useTxModalStagesClaimBond = () =>
                 }
               />
             ),
-            {
-              isClosableOnLedger: true,
-            },
           ),
       };
     },

--- a/features/claim-type/claim-ics-form/hooks/use-tx-modal-stages-claim-ics.tsx
+++ b/features/claim-type/claim-ics-form/hooks/use-tx-modal-stages-claim-ics.tsx
@@ -30,7 +30,6 @@ export const useTxModalStagesClaimIcs = () =>
             title="ICS type has been successfully claimed"
             description=""
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/claim-type/claim-idvtc-form/hooks/use-tx-modal-stages-claim-idvtc.tsx
+++ b/features/claim-type/claim-idvtc-form/hooks/use-tx-modal-stages-claim-idvtc.tsx
@@ -30,7 +30,6 @@ export const useTxModalStagesClaimIdvtc = () =>
             title="IDVTC type has been successfully claimed"
             description=""
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/create-node-operator/curated-operator-form/hooks/use-tx-modal-stages-curated-operator.tsx
+++ b/features/create-node-operator/curated-operator-form/hooks/use-tx-modal-stages-curated-operator.tsx
@@ -83,9 +83,6 @@ export const useTxModalStagesCuratedOperator = () =>
               )
             }
           />,
-          {
-            isClosableOnLedger: true,
-          },
         );
       },
     };

--- a/features/create-node-operator/submit-keys-form/hooks/use-tx-modal-stages-submit-keys.tsx
+++ b/features/create-node-operator/submit-keys-form/hooks/use-tx-modal-stages-submit-keys.tsx
@@ -91,9 +91,6 @@ export const useTxModalStagesSubmitKeys = () =>
               ) : undefined
             }
           />,
-          {
-            isClosableOnLedger: true,
-          },
         );
       },
     };

--- a/features/delayed-penalty/delayed-penalty-cancel-form/hooks/use-tx-modal-stages-delayed-penalty-cancel.tsx
+++ b/features/delayed-penalty/delayed-penalty-cancel-form/hooks/use-tx-modal-stages-delayed-penalty-cancel.tsx
@@ -59,6 +59,5 @@ export const useTxModalStagesDelayedPenaltyCancel = () =>
             </>
           }
         />,
-        { isClosableOnLedger: true },
       ),
   }));

--- a/features/delayed-penalty/delayed-penalty-report-form/hooks/use-tx-modal-stages-delayed-penalty-report.tsx
+++ b/features/delayed-penalty/delayed-penalty-report-form/hooks/use-tx-modal-stages-delayed-penalty-report.tsx
@@ -59,6 +59,5 @@ export const useTxModalStagesDelayedPenaltyReport = () =>
             </>
           }
         />,
-        { isClosableOnLedger: true },
       ),
   }));

--- a/features/dvt/apply-form/context/use-modal-stages.tsx
+++ b/features/dvt/apply-form/context/use-modal-stages.tsx
@@ -52,7 +52,6 @@ const getModalStages = (transitStage: TransactionModalTransitStage) => ({
         error={errorContent}
         code={getErrorCode(error)}
       />,
-      { isClosableOnLedger: true },
     );
   },
 });

--- a/features/eject-keys/eject-keys/hooks/use-tx-modal-stages-eject-keys.tsx
+++ b/features/eject-keys/eject-keys/hooks/use-tx-modal-stages-eject-keys.tsx
@@ -44,7 +44,6 @@ export const useTxModalStagesEjectKeys = () =>
             }
             description=""
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/ics/apply-form/context/use-modal-stages.tsx
+++ b/features/ics/apply-form/context/use-modal-stages.tsx
@@ -56,7 +56,6 @@ export const useModalStages = () => {
             error={errorContent}
             code={getErrorCode(error)}
           />,
-          { isClosableOnLedger: true },
         );
       },
     }),

--- a/features/metadata/metadata-form/hooks/use-tx-modal-stages-metadata.tsx
+++ b/features/metadata/metadata-form/hooks/use-tx-modal-stages-metadata.tsx
@@ -34,7 +34,6 @@ export const useTxModalStagesMetadata = () =>
             description="Name and description have been updated"
             txHash={txHash}
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/normalize-queue/normalize-queue-form/hooks/use-tx-modal-stages-normalize-queue.tsx
+++ b/features/normalize-queue/normalize-queue-form/hooks/use-tx-modal-stages-normalize-queue.tsx
@@ -39,7 +39,6 @@ export const useTxModalStagesNormalizeQueue = () =>
               title="Queue has been normalized"
               description={`You have ${keysCount} keys(s) in depositing queue`}
             />,
-            { isClosableOnLedger: true },
           ),
       };
     },

--- a/features/remove-keys/remove-keys/hooks/use-tx-modal-stages-remove-keys.tsx
+++ b/features/remove-keys/remove-keys/hooks/use-tx-modal-stages-remove-keys.tsx
@@ -44,7 +44,6 @@ export const useTxModalStagesRemoveKeys = () =>
             }
             description=""
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/unlock-bond/unlock-bond-form/hooks/use-tx-modal-stages-compensate.tsx
+++ b/features/unlock-bond/unlock-bond-form/hooks/use-tx-modal-stages-compensate.tsx
@@ -51,7 +51,6 @@ export const useTxModalStagesCompensate = () =>
               ) : undefined
             }
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/features/unlock-bond/unlock-bond-form/hooks/use-tx-modal-stages-unlock-expired.tsx
+++ b/features/unlock-bond/unlock-bond-form/hooks/use-tx-modal-stages-unlock-expired.tsx
@@ -30,7 +30,6 @@ export const useTxModalStagesUnlockExpired = () =>
             title="Expired bond lock has been unlocked"
             description={undefined}
           />,
-          { isClosableOnLedger: true },
         ),
     }),
   );

--- a/shared/transaction-modal/hooks/get-general-transaction-modal-stages.tsx
+++ b/shared/transaction-modal/hooks/get-general-transaction-modal-stages.tsx
@@ -30,18 +30,13 @@ export const getGeneralTransactionModalStages = (
         txHash={txHash}
       />,
     ),
-  successMultisig: () =>
-    transitStage(<TxStageSuccessMultisig />, {
-      isClosableOnLedger: true,
-    }),
+  successMultisig: () => transitStage(<TxStageSuccessMultisig />),
   failed: (error: unknown) => {
     const code = getErrorCode(error);
     const errorMessage =
       code === ErrorCode.SOMETHING_WRONG
         ? extractErrorMessage(error)
         : undefined;
-    return transitStage(<TxStageFail code={code} error={errorMessage} />, {
-      isClosableOnLedger: true,
-    });
+    return transitStage(<TxStageFail code={code} error={errorMessage} />);
   },
 });

--- a/shared/transaction-modal/index.ts
+++ b/shared/transaction-modal/index.ts
@@ -1,4 +1,5 @@
 export * from './handle-tx-error';
+export * from './is-closable-on-ledger';
 export * from './transaction-modal-content';
 export * from './transaction-modal';
 export * from './hooks';

--- a/shared/transaction-modal/is-closable-on-ledger.ts
+++ b/shared/transaction-modal/is-closable-on-ledger.ts
@@ -1,0 +1,19 @@
+import { isValidElement, type ReactNode } from 'react';
+
+/**
+ * Marker for terminal stage components (success / fail) that may be dismissed
+ * even on Ledger, where the transaction modal is otherwise locked while a
+ * signature is pending. Attach it to the stage component itself
+ * (`MyStage.isClosableOnLedger = true`) so closability is derived from what is
+ * rendered instead of being repeated at every call site.
+ */
+export type ClosableOnLedgerStage = { isClosableOnLedger?: boolean };
+
+export const isClosableOnLedgerStage = (node: ReactNode): boolean => {
+  if (!isValidElement(node)) return false;
+  const { type } = node;
+  return (
+    typeof type !== 'string' &&
+    (type as ClosableOnLedgerStage).isClosableOnLedger === true
+  );
+};

--- a/shared/transaction-modal/transaction-modal.tsx
+++ b/shared/transaction-modal/transaction-modal.tsx
@@ -3,24 +3,25 @@ import { Modal } from '@lidofinance/lido-ui';
 import { useConnectorInfo } from 'reef-knot/core-react';
 import { getUseModal, ModalComponentType } from 'providers/modal-provider';
 import { getFormRetry } from 'shared/hook-form/form-controller/form-retry';
+import { isClosableOnLedgerStage } from './is-closable-on-ledger';
 
 const ModalRetryContext = createContext<(() => void) | undefined>(undefined);
 export const useModalRetry = () => useContext(ModalRetryContext);
 
 type TransactionModalProps = {
-  isClosableOnLedger?: boolean;
   children?: React.ReactNode;
 };
 
 export const TransactionModal: ModalComponentType<TransactionModalProps> = ({
   open,
-  isClosableOnLedger,
   onClose,
   children,
   ...props
 }) => {
   const { isLedger } = useConnectorInfo();
-  const isClosable = !isLedger || isClosableOnLedger;
+  // Terminal stages (success / fail) mark themselves dismissible; every other
+  // stage keeps the modal locked while a Ledger signature is pending.
+  const isClosable = !isLedger || isClosableOnLedgerStage(children);
   const onRetry = getFormRetry();
 
   return (

--- a/shared/transaction-modal/tx-stages-basic/tx-stage-fail.tsx
+++ b/shared/transaction-modal/tx-stages-basic/tx-stage-fail.tsx
@@ -3,6 +3,7 @@ import { FC, ReactNode, useCallback, useState } from 'react';
 import { Loader } from '@lidofinance/lido-ui';
 import { TransactionModalContent } from 'shared/transaction-modal/transaction-modal-content';
 import { useModalRetry } from 'shared/transaction-modal/transaction-modal';
+import type { ClosableOnLedgerStage } from 'shared/transaction-modal/is-closable-on-ledger';
 import { StageIconFail } from './icons';
 import { LoaderWrapper, RetryButtonStyled } from './styles';
 import { ErrorCode } from 'utils';
@@ -14,7 +15,7 @@ type TxStageFailProps = {
   error?: ReactNode;
 };
 
-export const TxStageFail: FC<TxStageFailProps> = ({
+export const TxStageFail: FC<TxStageFailProps> & ClosableOnLedgerStage = ({
   code = ErrorCode.SOMETHING_WRONG,
   title = 'Transaction Failed',
   error,
@@ -44,3 +45,7 @@ export const TxStageFail: FC<TxStageFailProps> = ({
     />
   );
 };
+
+// Terminal stage: dismissible even on Ledger (modal is otherwise locked while
+// a signature is pending).
+TxStageFail.isClosableOnLedger = true;

--- a/shared/transaction-modal/tx-stages-basic/tx-stage-success-multisig.tsx
+++ b/shared/transaction-modal/tx-stages-basic/tx-stage-success-multisig.tsx
@@ -1,7 +1,9 @@
+import { type FC } from 'react';
 import { TransactionModalContent } from 'shared/transaction-modal/transaction-modal-content';
+import type { ClosableOnLedgerStage } from 'shared/transaction-modal/is-closable-on-ledger';
 import { StageIconSuccess } from './icons';
 
-export const TxStageSuccessMultisig = () => {
+export const TxStageSuccessMultisig: FC & ClosableOnLedgerStage = () => {
   return (
     <TransactionModalContent
       icon={<StageIconSuccess />}
@@ -10,3 +12,7 @@ export const TxStageSuccessMultisig = () => {
     />
   );
 };
+
+// Terminal stage: dismissible even on Ledger (modal is otherwise locked while
+// a signature is pending).
+TxStageSuccessMultisig.isClosableOnLedger = true;

--- a/shared/transaction-modal/tx-stages-basic/tx-stage-success.tsx
+++ b/shared/transaction-modal/tx-stages-basic/tx-stage-success.tsx
@@ -1,5 +1,7 @@
+import { type FC } from 'react';
 import { TxLinkEtherscan } from 'shared/components/tx-link-etherscan';
 import { TransactionModalContent } from 'shared/transaction-modal/transaction-modal-content';
+import type { ClosableOnLedgerStage } from 'shared/transaction-modal/is-closable-on-ledger';
 import { StageIconSuccess } from './icons';
 
 type TxStageSuccessProps = {
@@ -10,13 +12,14 @@ type TxStageSuccessProps = {
   showEtherscan?: boolean;
 };
 
-export const TxStageSuccess = ({
+export const TxStageSuccess: FC<TxStageSuccessProps> &
+  ClosableOnLedgerStage = ({
   txHash,
   description,
   title,
   footer,
   showEtherscan = true,
-}: TxStageSuccessProps) => {
+}) => {
   return (
     <TransactionModalContent
       icon={<StageIconSuccess />}
@@ -29,3 +32,7 @@ export const TxStageSuccess = ({
     />
   );
 };
+
+// Terminal stage: dismissible even on Ledger (modal is otherwise locked while
+// a signature is pending).
+TxStageSuccess.isClosableOnLedger = true;

--- a/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
+++ b/shared/transaction-modal/tx-stages-composed/tx-stage-operation-succeed-balance-shown.tsx
@@ -1,9 +1,11 @@
+import { type FC } from 'react';
 import styled from 'styled-components';
 
 import { InlineLoader } from '@lidofinance/lido-ui';
 import { TxAmount } from '../tx-stages-parts/tx-amount';
 import { SuccessText } from '../tx-stages-parts/success-text';
 import { TxStageSuccess } from '../tx-stages-basic';
+import type { ClosableOnLedgerStage } from '../is-closable-on-ledger';
 import { TOKENS } from '@lidofinance/lido-csm-sdk';
 
 export const SkeletonBalance = styled(InlineLoader).attrs({
@@ -20,12 +22,13 @@ type TxStageOperationSucceedBalanceShownProps = {
   txHash?: string;
 };
 
-export const TxStageOperationSucceedBalanceShown = ({
+export const TxStageOperationSucceedBalanceShown: FC<TxStageOperationSucceedBalanceShownProps> &
+  ClosableOnLedgerStage = ({
   balance,
   balanceToken,
   operationText,
   txHash,
-}: TxStageOperationSucceedBalanceShownProps) => {
+}) => {
   const balanceEl = !!balance && (
     <TxAmount amount={balance} token={balanceToken} />
   );
@@ -46,3 +49,7 @@ export const TxStageOperationSucceedBalanceShown = ({
     />
   );
 };
+
+// Terminal stage: dismissible even on Ledger (modal is otherwise locked while
+// a signature is pending).
+TxStageOperationSucceedBalanceShown.isClosableOnLedger = true;


### PR DESCRIPTION
### 📚 Stacked PR — merge bottom-up
- #542 — deps & tooling _(base ← `develop`)_
- 👉 **#543 — tx-modal closable on Ledger**
- #544 — claim-bond compensate copy
- #545 — add-keys / deposit-data / add-bond
- #546 — dvt apply-form
- #547 — misc UI (tooltip, rewards, change-role, delayed-penalty)

_Replaces the single large #539. Each PR targets the one below it; review/merge from #542 upward. Rebasing a lower PR cascades upward._

---

Make terminal tx-modal stages closable on Ledger by construction. Cross-cutting refactor of the transaction-modal stage hooks (28 files, single concern).
