### PR TITLE
fix(claim-bond): compensate-copy fixes + mock stand [stack 3/6]

### DIFF
--- a/features/claim-bond/claim-bond-form/controls/amount-input.tsx
+++ b/features/claim-bond/claim-bond-form/controls/amount-input.tsx
@@ -1,4 +1,4 @@
-import { TOKENS } from '@lidofinance/lido-csm-sdk';
+import { STETH_ROUNDING_THRESHOLD, TOKENS } from '@lidofinance/lido-csm-sdk';
 import { useWatch } from 'react-hook-form';
 import { FormTitle, Note } from 'shared/components';
 import { FormatToken } from 'shared/formatters';
@@ -55,7 +55,7 @@ export const AmountInput: React.FC = () => {
         maxValue={maxAmount}
         disabled={!maxAmount}
       />
-      {coverAmount > 0n && (
+      {coverAmount > STETH_ROUNDING_THRESHOLD && (
         <Note>
           <FormatToken amount={coverAmount} token={TOKENS.steth} /> of Rewards
           will compensate for the Insufficient Bond (

--- a/features/claim-bond/claim-bond-form/hooks/use-claim-options.tsx
+++ b/features/claim-bond/claim-bond-form/hooks/use-claim-options.tsx
@@ -186,6 +186,15 @@ const describe = (
       };
 
     case CLAIM_OPTION.REWARDS_TO_BOND: {
+      // Rewards don't cover the insufficient bond (rewardsRemainder === 0): the
+      // whole amount compensates the bond, nothing is split and nothing reaches
+      // excess — so use the compensation copy even with splitters configured.
+      if (isKeysInsufficient && rewardsRemainder === 0n) {
+        return {
+          ...COMPENSATE_INSUFFICIENT,
+          submitLabel: rewardsToBondSubmit(rewardsRemainder),
+        };
+      }
       if (hasSplits) {
         return {
           ...SPLIT_REWARDS_TO_BOND,

--- a/features/claim-bond/claim-bond-form/hooks/use-claim-options.tsx
+++ b/features/claim-bond/claim-bond-form/hooks/use-claim-options.tsx
@@ -1,5 +1,10 @@
 import { ReactNode } from 'react';
-import { BondBalance, FeeSplit, TOKENS } from '@lidofinance/lido-csm-sdk';
+import {
+  BondBalance,
+  FeeSplit,
+  STETH_ROUNDING_THRESHOLD,
+  TOKENS,
+} from '@lidofinance/lido-csm-sdk';
 import { useWatch } from 'react-hook-form';
 import styled, { css } from 'styled-components';
 
@@ -151,7 +156,7 @@ const describe = (
   // Locked/debt absorb rewards into bond too, but the operator does not see
   // "Insufficient bond" in sources-info, so the Claim variants are used and
   // the breakdown panel reflects the actual on-chain effect.
-  const isKeysInsufficient = keysInsufficient > 0n;
+  const isKeysInsufficient = keysInsufficient > STETH_ROUNDING_THRESHOLD;
 
   switch (option) {
     case CLAIM_OPTION.ALL_TO_RA: {

--- a/mock/claim-bond/debug-panel.tsx
+++ b/mock/claim-bond/debug-panel.tsx
@@ -1,0 +1,104 @@
+import { Accordion, Block, Text } from '@lidofinance/lido-ui';
+import { useClaimBondFormData } from 'features/claim-bond/claim-bond-form/context';
+import { type CLAIM_OPTION } from 'features/claim-bond/claim-bond-form/context/types';
+import { FC } from 'react';
+import styled from 'styled-components';
+import { formatEther } from 'viem';
+
+const f = (v?: bigint) => formatEther(v ?? 0n);
+
+// Reads the derived network data straight from the form's context, so the panel
+// shows exactly what the rendered form computed (no parallel re-derivation), and
+// cross-checks the real availableOptions against the scenario's expectation.
+export const ClaimBondDebugPanel: FC<{
+  expectOptions?: CLAIM_OPTION[];
+  expectEmpty?: boolean;
+}> = ({ expectOptions, expectEmpty }) => {
+  const data = useClaimBondFormData();
+
+  if (!data?.bond || !data.calculation) return null;
+
+  const {
+    bond,
+    rewards,
+    calculation: c,
+    availableOptions = [],
+    feeSplits = [],
+    isPaused,
+    isContract,
+  } = data;
+
+  const actual = [...availableOptions].sort().join(', ') || '—';
+  const expected = expectEmpty
+    ? '—'
+    : [...(expectOptions ?? [])].sort().join(', ') || '—';
+  const hasExpectation = expectEmpty || !!expectOptions;
+  const match = !hasExpectation || actual === expected;
+
+  return (
+    <TestBlock>
+      <StyledAccordion
+        summary={
+          <Text size="xs" color="secondary">
+            Raw inputs &amp; derived calculation{' '}
+            {match ? '✓' : '✗ options mismatch'}
+          </Text>
+        }
+      >
+        <DataPre>
+          {[
+            `current:                 ${f(bond.current)}`,
+            `required (forKeys):      ${f(bond.required)}`,
+            `locked:                  ${f(bond.locked)}`,
+            `debt:                    ${f(bond.debt)}`,
+            `pendingToSplit:          ${f(bond.pendingToSplit)}`,
+            `delta:                   ${f(bond.delta)}  (isInsufficient: ${bond.isInsufficient})`,
+            `rewards.available:       ${f(rewards?.available)}`,
+            `feeSplits:               ${
+              feeSplits.map((s) => `${Number(s.share) / 100}%`).join(', ') ||
+              '—'
+            }`,
+            '—',
+            `realExcess:              ${f(c.realExcess)}`,
+            `realInsufficient:        ${f(c.realInsufficient)}`,
+            `keysInsufficient:        ${f(c.keysInsufficient)}`,
+            `claimableBond:           ${f(c.claimableBond)}`,
+            `claimableBondAndRewards: ${f(c.claimableBondAndRewards)}`,
+            `rewardsRemainder:        ${f(c.rewardsRemainder)}`,
+            '—',
+            `availableOptions:        [${actual}]`,
+            `expectedOptions:         [${expected}]  ${match ? '✓' : '✗ MISMATCH'}`,
+            `isPaused: ${isPaused}   isContract: ${isContract}`,
+          ].join('\n')}
+        </DataPre>
+      </StyledAccordion>
+    </TestBlock>
+  );
+};
+
+const TestBlock = styled(Block)`
+  padding: 16px;
+`;
+
+const StyledAccordion = styled(Accordion)`
+  & > [type='button'] {
+    padding: 0;
+    min-height: 24px;
+  }
+  & > [type='button'] + div > div {
+    padding: 8px 0 0;
+  }
+`;
+
+const DataPre = styled.pre`
+  background: var(--lido-color-backgroundSecondary);
+  border-radius: 8px;
+  padding: 16px;
+  margin: 0;
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-x: auto;
+`;

--- a/mock/claim-bond/mock-data.ts
+++ b/mock/claim-bond/mock-data.ts
@@ -1,0 +1,104 @@
+import {
+  type BondBalance,
+  type FeeSplit,
+  type FrameInfo,
+  type NodeOperatorInfo,
+  type Rewards,
+  type StethPoolData,
+} from '@lidofinance/lido-csm-sdk';
+import { Address, parseEther } from 'viem';
+
+// Pure builders + fixtures for the claim-bond test stand. Intentionally free of
+// wagmi / web3-provider imports so the scenario unit tests stay lightweight —
+// the mock wagmi config lives in `./mock-wagmi`.
+
+const eth = (n: number) => parseEther(n.toString());
+
+export const MOCK_CLAIMER: Address =
+  '0x1111111111111111111111111111111111111111';
+export const MOCK_REWARDS_ADDRESS: Address =
+  '0x2222222222222222222222222222222222222222';
+
+export const MOCK_POOL_DATA: StethPoolData = {
+  totalPooledEther: parseEther('1000000'),
+  totalShares: parseEther('900000'),
+};
+
+// Far-future nextReport so getNextDistribution renders "on <date>", not "soon".
+export const MOCK_FRAME: FrameInfo = {
+  lastReport: 1700000000,
+  nextReport: 4102444800,
+  frameDuration: 28 * 24 * 60 * 60,
+};
+
+export type RawBond = {
+  /** held bond, ether */
+  current: number;
+  /** forKeys-only requirement, ether (matches SDK BondBalance.required) */
+  forKeys: number;
+  locked?: number;
+  /** Unsettled bond debt. Real-world invariant: debt is burned from the bond on
+   * every touch, so debt > 0 only ever coexists with current === 0. */
+  debt?: number;
+  pendingToSplit?: number;
+};
+
+// Mirrors calcBondBalance output semantics: required = forKeys,
+// delta = |current - forKeys|, isInsufficient = current < forKeys.
+export const makeBond = ({
+  current,
+  forKeys,
+  locked = 0,
+  debt = 0,
+  pendingToSplit = 0,
+}: RawBond): BondBalance => {
+  const c = eth(current);
+  const required = eth(forKeys);
+  const delta = c - required;
+  return {
+    required,
+    current: c,
+    locked: eth(locked),
+    debt: eth(debt),
+    pendingToSplit: eth(pendingToSplit),
+    delta: delta < 0n ? -delta : delta,
+    isInsufficient: delta < 0n,
+  };
+};
+
+export const makeRewards = (available: number): Rewards => ({
+  available: eth(available),
+  shares: eth(available),
+  proof: [],
+});
+
+// sharesPct in percent (50 → 5000n basis points); recipients are deterministic.
+export const makeFeeSplits = (...sharesPct: number[]): FeeSplit[] =>
+  sharesPct.map((pct, i) => ({
+    recipient: `0x${String(i + 1)
+      .repeat(40)
+      .slice(0, 40)}`,
+    share: BigInt(Math.round(pct * 100)),
+  }));
+
+export const makeOperatorInfo = ({
+  rewardsAddress,
+}: {
+  rewardsAddress: Address;
+}): NodeOperatorInfo =>
+  ({
+    totalAddedKeys: 10,
+    totalWithdrawnKeys: 0,
+    totalDepositedKeys: 8,
+    totalVettedKeys: 10,
+    stuckValidatorsCount: 0,
+    depositableValidatorsCount: 2,
+    targetLimit: 0,
+    targetLimitMode: 0,
+    totalExitedKeys: 0,
+    enqueuedCount: 0,
+    managerAddress: MOCK_CLAIMER,
+    rewardsAddress,
+    extendedManagerPermissions: false,
+    usedPriorityQueue: false,
+  }) as NodeOperatorInfo;

--- a/mock/claim-bond/mock-data.ts
+++ b/mock/claim-bond/mock-data.ts
@@ -1,4 +1,5 @@
 import {
+  STETH_ROUNDING_THRESHOLD,
   type BondBalance,
   type FeeSplit,
   type FrameInfo,
@@ -41,20 +42,27 @@ export type RawBond = {
    * every touch, so debt > 0 only ever coexists with current === 0. */
   debt?: number;
   pendingToSplit?: number;
+  /** Wei shaved off `current` to model a sub-precision forKeys deficit (e.g. 5
+   * → current sits 5 wei below forKeys). The SDK clamps such share-rounding
+   * dust to Excess Bond 0.0; used to check no "compensate" copy leaks through. */
+  deficitWei?: number;
 };
 
-// Mirrors calcBondBalance output semantics: required = forKeys,
-// delta = |current - forKeys|, isInsufficient = current < forKeys.
+// Mirrors calcBondBalance output semantics: required = forKeys, delta =
+// |current - forKeys| clamped to 0 within STETH_ROUNDING_THRESHOLD (share-
+// rounding dust), isInsufficient = current < forKeys beyond that threshold.
 export const makeBond = ({
   current,
   forKeys,
   locked = 0,
   debt = 0,
   pendingToSplit = 0,
+  deficitWei = 0,
 }: RawBond): BondBalance => {
-  const c = eth(current);
+  const c = eth(current) - BigInt(deficitWei);
   const required = eth(forKeys);
-  const delta = c - required;
+  const raw = c - required;
+  const delta = raw < 0n && raw > -STETH_ROUNDING_THRESHOLD ? 0n : raw;
   return {
     required,
     current: c,

--- a/mock/claim-bond/mock-providers.tsx
+++ b/mock/claim-bond/mock-providers.tsx
@@ -1,0 +1,146 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useUserConfig } from 'config/user-config';
+import { STRATEGY_IMMUTABLE } from 'consts';
+import { ClaimBondForm } from 'features/claim-bond/claim-bond-form';
+import { ClaimBondDataProvider } from 'features/claim-bond/claim-bond-form/context';
+import {
+  KEY_FEE_SPLITS,
+  KEY_OPERATOR_BALANCE,
+  KEY_OPERATOR_INFO,
+  KEY_OPERATOR_REWARDS,
+  KEY_STETH_POOL_DATA,
+  useDappStatus,
+} from 'modules/web3';
+import {
+  NodeOperatorContext,
+  type NodeOperatorContextValue,
+} from 'modules/web3/operator-provider/node-operator-provider';
+import { FC, PropsWithChildren, useEffect, useMemo } from 'react';
+import { hashKey } from 'utils';
+import { WagmiProvider, useConnect, useConnection } from 'wagmi';
+import {
+  makeBond,
+  makeFeeSplits,
+  makeOperatorInfo,
+  makeRewards,
+  MOCK_CLAIMER,
+  MOCK_FRAME,
+  MOCK_POOL_DATA,
+  MOCK_REWARDS_ADDRESS,
+} from './mock-data';
+import { createMockWagmiConfig } from './mock-wagmi';
+import { type ClaimBondScenarioData } from './scenarios';
+
+// Auto-connects the mock connector on mount so useDappStatus() reports a
+// connected address. Renders nothing until connected to avoid a "no-access"
+// flash and any SSR/client hydration mismatch (server render is unconnected).
+const AutoConnect: FC<PropsWithChildren> = ({ children }) => {
+  const { isConnected } = useConnection();
+  const { connect, connectors } = useConnect();
+  useEffect(() => {
+    if (!isConnected && connectors[0]) {
+      connect({ connector: connectors[0] });
+    }
+  }, [isConnected, connect, connectors]);
+  return isConnected ? <>{children}</> : null;
+};
+
+// Supplies the node operator context for the stand. Must live inside the
+// WagmiProvider so it can read the actually-connected address: it mirrors that
+// address onto `managerAddress` so the CLAIMER access gate passes whoever is
+// connected — the mock account or a real wallet leaked in from another page
+// (wagmi auto-discovers injected wallets and reconnects them from storage).
+const MockOperatorProvider: FC<
+  PropsWithChildren<{ nodeOperatorId: bigint }>
+> = ({ nodeOperatorId, children }) => {
+  const { address } = useDappStatus();
+
+  const operatorCtx: NodeOperatorContextValue = useMemo(
+    () => ({
+      isPending: false,
+      nodeOperator: {
+        nodeOperatorId,
+        managerAddress: address ?? MOCK_CLAIMER,
+        rewardsAddress: MOCK_REWARDS_ADDRESS,
+        extendedManagerPermissions: false,
+        curveId: 0n,
+      },
+      switchNodeOperator: () => {},
+    }),
+    [nodeOperatorId, address],
+  );
+
+  return (
+    <NodeOperatorContext.Provider value={operatorCtx}>
+      {children}
+    </NodeOperatorContext.Provider>
+  );
+};
+
+export const MockClaimBondProvider: FC<
+  PropsWithChildren<{ scenario: ClaimBondScenarioData }>
+> = ({ scenario, children }) => {
+  const { defaultChain } = useUserConfig();
+  const nodeOperatorId = BigInt(scenario.nodeOperatorId ?? 1);
+
+  const wagmiConfig = useMemo(
+    () => createMockWagmiConfig(defaultChain, MOCK_CLAIMER),
+    [defaultChain],
+  );
+
+  const queryClient = useMemo(() => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          queryKeyHashFn: hashKey,
+          retry: false,
+          ...STRATEGY_IMMUTABLE,
+        },
+      },
+    });
+    const idKey = { nodeOperatorId };
+    client.setQueryData(
+      [...KEY_OPERATOR_BALANCE, idKey],
+      makeBond(scenario.bond),
+    );
+    client.setQueryData(
+      [...KEY_OPERATOR_REWARDS, idKey],
+      makeRewards(scenario.rewards ?? 0),
+    );
+    client.setQueryData(
+      [...KEY_OPERATOR_INFO, idKey],
+      makeOperatorInfo({ rewardsAddress: MOCK_REWARDS_ADDRESS }),
+    );
+    client.setQueryData(
+      [...KEY_FEE_SPLITS, idKey],
+      scenario.feeSplits ? makeFeeSplits(...scenario.feeSplits) : [],
+    );
+    client.setQueryData([...KEY_STETH_POOL_DATA], MOCK_POOL_DATA);
+    client.setQueryData(['sm-status'], {
+      isPausedModule: false,
+      isPausedAccounting: !!scenario.isPaused,
+    });
+    client.setQueryData(['frame-info'], MOCK_FRAME);
+    client.setQueryData(
+      ['use-is-contract', MOCK_REWARDS_ADDRESS],
+      !!scenario.isContract,
+    );
+    return client;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scenario]);
+
+  return (
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        <AutoConnect>
+          <MockOperatorProvider nodeOperatorId={nodeOperatorId}>
+            <ClaimBondForm />
+            {children && (
+              <ClaimBondDataProvider>{children}</ClaimBondDataProvider>
+            )}
+          </MockOperatorProvider>
+        </AutoConnect>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+};

--- a/mock/claim-bond/mock-wagmi.ts
+++ b/mock/claim-bond/mock-wagmi.ts
@@ -1,0 +1,21 @@
+import { wagmiChainMap } from 'modules/web3/web3-provider/web3-provider';
+import { Address } from 'viem';
+import { Config, createConfig, http } from 'wagmi';
+import { mock } from 'wagmi/connectors';
+
+// A self-contained wagmi config with a mock connector pre-set to `account`.
+// The connector auto-connects on mount (see MockClaimBondProvider) so that
+// useDappStatus() reports a connected address on the stand's default chain —
+// enough to satisfy the claimBond CLAIMER access gate without a real wallet.
+export const createMockWagmiConfig = (
+  chainId: number,
+  account: Address,
+): Config => {
+  const chain = wagmiChainMap[chainId];
+  return createConfig({
+    chains: [chain],
+    connectors: [mock({ accounts: [account] })],
+    transports: { [chain.id]: http() },
+    ssr: false,
+  });
+};

--- a/mock/claim-bond/scenarios.ts
+++ b/mock/claim-bond/scenarios.ts
@@ -1,0 +1,222 @@
+import { CLAIM_OPTION } from 'features/claim-bond/claim-bond-form/context/types';
+import { type RawBond } from './mock-data';
+
+export type ClaimBondScenarioData = {
+  nodeOperatorId?: number;
+  bond: RawBond;
+  rewards?: number;
+  feeSplits?: number[];
+  isPaused?: boolean;
+  isContract?: boolean;
+};
+
+export type ClaimBondScenario = {
+  group: string;
+  title: string;
+  description: string;
+  data: ClaimBondScenarioData;
+  expectEmpty?: boolean;
+  expectOptions?: CLAIM_OPTION[];
+};
+
+const ALL = CLAIM_OPTION.ALL_TO_RA;
+const BOND = CLAIM_OPTION.BOND_TO_RA;
+const R2B = CLAIM_OPTION.REWARDS_TO_BOND;
+
+export const testScenarios: ClaimBondScenario[] = [
+  // [Basic]
+  {
+    group: 'Basic',
+    title: 'Excess + rewards',
+    description:
+      'Classic state: claimable excess bond and pending rewards. All three options.',
+    data: { bond: { current: 34, forKeys: 32 }, rewards: 0.4 },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  {
+    group: 'Basic',
+    title: 'Excess only',
+    description: 'Excess bond, no rewards. Only Excess Bond → Rewards Address.',
+    data: { bond: { current: 34, forKeys: 32 }, rewards: 0 },
+    expectOptions: [BOND],
+  },
+  {
+    group: 'Basic',
+    title: 'Rewards only (bond exact)',
+    description:
+      'Bond exactly covers keys, rewards pending. Excess Bond option disabled.',
+    data: { bond: { current: 32, forKeys: 32 }, rewards: 0.4 },
+    expectOptions: [ALL, R2B],
+  },
+  {
+    group: 'Basic',
+    title: 'Nothing to claim',
+    description: 'No excess, no rewards. Empty state.',
+    data: { bond: { current: 32, forKeys: 32 }, rewards: 0 },
+    expectEmpty: true,
+  },
+  // [Insufficient]
+  {
+    group: 'Insufficient',
+    title: 'Insufficient, rewards > deficit',
+    description:
+      'Rewards cover the forKeys deficit with a remainder reaching the Rewards Address.',
+    data: { bond: { current: 31, forKeys: 32 }, rewards: 1.5 },
+    expectOptions: [ALL, R2B],
+  },
+  {
+    group: 'Insufficient',
+    title: 'Insufficient, rewards < deficit',
+    description:
+      'Rewards fully absorbed by the bond top-up. Nothing reaches the Rewards Address.',
+    data: { bond: { current: 30, forKeys: 32 }, rewards: 0.5 },
+    expectOptions: [R2B],
+  },
+  {
+    group: 'Insufficient',
+    title: 'Insufficient, no rewards',
+    description: 'Deficit but no rewards. Empty state.',
+    data: { bond: { current: 30, forKeys: 32 }, rewards: 0 },
+    expectEmpty: true,
+  },
+  // [Locked]
+  {
+    group: 'Locked',
+    title: 'Excess + locked + rewards',
+    description:
+      'Excess remains above required + locked. Locked row shows with its tooltip.',
+    data: { bond: { current: 35, forKeys: 32, locked: 1 }, rewards: 0.4 },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  {
+    group: 'Locked',
+    title: 'Locked-induced real deficit',
+    description:
+      'forKeys covered (shows excess) but locked eats it. Rewards absorbed into bond.',
+    data: { bond: { current: 32.5, forKeys: 32, locked: 1 }, rewards: 0.4 },
+    expectOptions: [R2B],
+  },
+  // [Debt] — real-world invariant: debt settles against bond on every touch
+  // (_coverBondDebt), so debt > 0 ⟹ current == 0. INV1 (debt ⟹ no excess) then
+  // holds trivially. All fixtures here keep current: 0.
+  {
+    group: 'Debt',
+    title: 'Debt + rewards > debt + deficit',
+    description:
+      'Rewards burn the debt and cover the deficit, remainder reaches the Rewards Address.',
+    data: { bond: { current: 0, forKeys: 2, debt: 1 }, rewards: 4 },
+    expectOptions: [ALL, R2B],
+  },
+  {
+    group: 'Debt',
+    title: 'Debt exceeds rewards',
+    description: 'Rewards partially burn debt; bond debt remaining is shown.',
+    data: { bond: { current: 0, forKeys: 4, debt: 2 }, rewards: 0.3 },
+    expectOptions: [R2B],
+  },
+  {
+    group: 'Debt',
+    title: 'Debt only, no rewards',
+    description: 'Debt alone produces nothing claimable. Empty state.',
+    data: { bond: { current: 0, forKeys: 32, debt: 1 }, rewards: 0 },
+    expectEmpty: true,
+  },
+  // [Splitters]
+  {
+    group: 'Splitters',
+    title: 'Excess + rewards + 50% splitter',
+    description: 'Single 50% splitter. SPLITTERS ON chip and split row appear.',
+    data: { bond: { current: 34, forKeys: 32 }, rewards: 1, feeSplits: [50] },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  {
+    group: 'Splitters',
+    title: 'Excess + rewards + 100% (two recipients)',
+    description: 'Two splitters summing to 100%. Multiple split rows.',
+    data: {
+      bond: { current: 34, forKeys: 32 },
+      rewards: 1,
+      feeSplits: [60, 40],
+    },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  {
+    group: 'Splitters',
+    title: 'Rewards + split, no excess',
+    description:
+      'Bond exact, rewards split with recipients. ALL option becomes split-rewards-only.',
+    data: { bond: { current: 32, forKeys: 32 }, rewards: 1, feeSplits: [50] },
+    expectOptions: [ALL, R2B],
+  },
+  {
+    group: 'Splitters',
+    title: 'Pending splitter debt + excess',
+    description:
+      'pendingToSplit settles from bond on claim. Splitter debt row shows.',
+    data: {
+      bond: { current: 34, forKeys: 32, pendingToSplit: 0.3 },
+      rewards: 0.5,
+      feeSplits: [50],
+    },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  {
+    group: 'Splitters',
+    title: 'Splitters + insufficient + remainder',
+    description:
+      'Split, compensate insufficient bond, send remainder to the Rewards Address.',
+    data: { bond: { current: 31, forKeys: 32 }, rewards: 2, feeSplits: [50] },
+    expectOptions: [ALL, R2B],
+  },
+  // [Misc]
+  {
+    group: 'Misc',
+    title: 'Paused accounting',
+    description: 'Accounting paused. Submit replaced by the paused button.',
+    data: {
+      bond: { current: 34, forKeys: 32 },
+      rewards: 0.4,
+      isPaused: true,
+    },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  {
+    group: 'Misc',
+    title: 'Rewards address is a contract',
+    description:
+      'Rewards address is a contract. Default claim token is wstETH.',
+    data: {
+      bond: { current: 34, forKeys: 32 },
+      rewards: 0.4,
+      isContract: true,
+    },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  {
+    group: 'Misc',
+    title: 'Whale (large excess + rewards)',
+    description: 'Large amounts. ETH max is capped by MAX_ETH_AMOUNT.',
+    data: { bond: { current: 1000, forKeys: 900 }, rewards: 50 },
+    expectOptions: [ALL, BOND, R2B],
+  },
+  // [Repro] States reported from the live app — used to check option copy.
+  {
+    group: 'Repro',
+    title: 'Insufficient + splitters, rewards < deficit',
+    description:
+      'forKeys-insufficient, splitters on, rewards do not cover the deficit (nothing splits, all compensates).',
+    data: { bond: { current: 31, forKeys: 32 }, rewards: 0.5, feeSplits: [40] },
+    expectOptions: [R2B],
+  },
+  {
+    group: 'Repro',
+    title: 'Locked hides excess + claimable rewards',
+    description:
+      'Excess shown but fully locked (no claimable excess); rewards exceed the tiny locked deficit, so most rewards are claimable.',
+    data: {
+      bond: { current: 42.0999, forKeys: 32, locked: 10.1 },
+      rewards: 0.2663,
+    },
+    expectOptions: [ALL, R2B],
+  },
+];

--- a/mock/claim-bond/scenarios.ts
+++ b/mock/claim-bond/scenarios.ts
@@ -219,4 +219,12 @@ export const testScenarios: ClaimBondScenario[] = [
     },
     expectOptions: [ALL, R2B],
   },
+  {
+    group: 'Repro',
+    title: 'Sub-threshold deficit (nothing to compensate)',
+    description:
+      'forKeys short by a few wei — SDK clamps to Excess Bond 0.0. No "compensate" copy or note should appear despite pending rewards.',
+    data: { bond: { current: 32, forKeys: 32, deficitWei: 5 }, rewards: 1.4779 },
+    expectOptions: [ALL, R2B],
+  },
 ];

--- a/pages/test/claim-bond.tsx
+++ b/pages/test/claim-bond.tsx
@@ -1,0 +1,93 @@
+import { Accordion, Block, Text } from '@lidofinance/lido-ui';
+import { ClaimBondDebugPanel } from 'mock/claim-bond/debug-panel';
+import { MockClaimBondProvider } from 'mock/claim-bond/mock-providers';
+import { testScenarios } from 'mock/claim-bond/scenarios';
+import { useRouter } from 'next/router';
+import { FC } from 'react';
+import { Stack } from 'shared/components';
+import { Layout } from 'shared/layout';
+import { LocalLink } from 'shared/navigate';
+import styled from 'styled-components';
+import { getFirstParam } from 'utils';
+import { getTestProps } from 'utilsApi';
+
+const TestContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 800px;
+  margin: 0 auto;
+`;
+
+const TestBlock = styled(Block)`
+  padding: 16px;
+`;
+
+const TestTitle = styled.h3`
+  margin: 0 0 8px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--lido-color-text);
+`;
+
+const TestDescription = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: var(--lido-color-textSecondary);
+`;
+
+const StyledAccordion = styled(Accordion)`
+  margin-top: 16px;
+  & > [type='button'] {
+    padding: 0;
+    min-height: 24px;
+  }
+  & > [type='button'] + div > div {
+    padding: 8px 0 0;
+  }
+`;
+
+const ClaimBondTestPage: FC = () => {
+  const { query } = useRouter();
+  const _case = parseInt(getFirstParam(query['case']) ?? '', 10) || 0;
+  const scenario = testScenarios[_case] ?? testScenarios[0];
+
+  return (
+    <Layout dummy title="Claim Bond Test">
+      <TestContainer>
+        <TestBlock>
+          <TestTitle>
+            [{scenario.group}] {scenario.title}
+          </TestTitle>
+          <TestDescription>{scenario.description}</TestDescription>
+          <StyledAccordion
+            summary={
+              <Text size="xs" color="secondary">
+                All cases ({testScenarios.length})
+              </Text>
+            }
+          >
+            <Stack direction="column" gap="xxs">
+              {testScenarios.map((s, i) => (
+                <LocalLink key={i} query={{ case: `${i}` }}>
+                  {i}: [{s.group}] {s.title}
+                </LocalLink>
+              ))}
+            </Stack>
+          </StyledAccordion>
+        </TestBlock>
+
+        <MockClaimBondProvider key={_case} scenario={scenario.data}>
+          <ClaimBondDebugPanel
+            expectOptions={scenario.expectOptions}
+            expectEmpty={scenario.expectEmpty}
+          />
+        </MockClaimBondProvider>
+      </TestContainer>
+    </Layout>
+  );
+};
+
+export default ClaimBondTestPage;
+
+export const getServerSideProps = getTestProps;


### PR DESCRIPTION
### 📚 Stacked PR — merge bottom-up
- #542 — deps & tooling _(base ← `develop`)_
- #543 — tx-modal closable on Ledger
- 👉 **#544 — claim-bond compensate copy**
- #545 — add-keys / deposit-data / add-bond
- #546 — dvt apply-form
- #547 — misc UI (tooltip, rewards, change-role, delayed-penalty)

_Replaces the single large #539. Each PR targets the one below it; review/merge from #542 upward. Rebasing a lower PR cascades upward._

---

Claim-bond compensate-copy fixes plus a mock test stand.
- show compensate copy when rewards don't cover insufficient bond
- add mock test stand covering realistic states
- suppress compensate copy for sub-threshold bond deficit
- add sub-threshold deficit scenario test
