### PR TITLE
fix(add-keys): add-keys/deposit-data/add-bond fixes [stack 4/6]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,8 @@ tsconfig.tsbuildinfo
 dev-cm
 
 # env
-.env.local
-.env.production
-.env.development
+.env*
+!.env.example
 
 # debug
 npm-debug.log*

--- a/features/add-bond/add-bond-form/controls/info.tsx
+++ b/features/add-bond/add-bond-form/controls/info.tsx
@@ -55,10 +55,10 @@ export const Info: FC = () => {
               >
                 unbonded
               </MatomoLink>{' '}
-              and being requested to exit in case of applied penalties
+              and being requested to exit in case of applied penalties.
               <br />
               Supplied bond will be stored as stETH, which also garners staking
-              rewards
+              rewards.
             </p>
           )}
         </Stack>

--- a/features/add-bond/add-bond-form/controls/info.tsx
+++ b/features/add-bond/add-bond-form/controls/info.tsx
@@ -2,7 +2,7 @@ import { TOKENS } from '@lidofinance/lido-csm-sdk';
 import { Text } from '@lidofinance/lido-ui';
 import { MATOMO_CLICK_EVENTS_TYPES } from 'consts';
 import { UNBONDED_VALIDATORS_LINK } from 'consts/external-links';
-import { BOND_INSUFFICIENT } from 'consts/text';
+import { BOND_EXCESS, BOND_INSUFFICIENT } from 'consts/text';
 import { FC } from 'react';
 import { Latice, MatomoLink, Stack, TitledAmount } from 'shared/components';
 import { useAddBondFormData } from '../context';
@@ -18,7 +18,7 @@ export const Info: FC = () => {
             warning={bond?.isInsufficient}
             title={
               <Text size="xxs" weight={700}>
-                {bond?.isInsufficient ? BOND_INSUFFICIENT : 'Bond balance'}
+                {bond?.isInsufficient ? BOND_INSUFFICIENT : BOND_EXCESS}
               </Text>
             }
             help={

--- a/features/add-keys/add-keys/add-keys-form.tsx
+++ b/features/add-keys/add-keys/add-keys-form.tsx
@@ -11,6 +11,7 @@ import { AddKeysFormLoader } from './add-keys-form-loader';
 import { AmountInput } from './controls/amount-input';
 import { KeysConfirm } from './controls/keys-confirm';
 import { KeysInput } from './controls/keys-input';
+import { KeysLimitWarning } from './controls/keys-limit-warning';
 import { SubmitButton } from './controls/submit-button';
 import { TokenSelect } from './controls/token-select';
 
@@ -22,6 +23,7 @@ export const AddKeysForm: FC = memo(() => {
           <AddKeysFormLoader>
             <Form>
               <TokenSelect />
+              <KeysLimitWarning />
               <KeysInput />
               <AmountInput />
               <KeysConfirm />

--- a/features/add-keys/add-keys/context/add-keys-data-provider.tsx
+++ b/features/add-keys/add-keys/context/add-keys-data-provider.tsx
@@ -23,7 +23,7 @@ import {
   NetworkData,
   useFormData,
 } from 'shared/hook-form/form-controller';
-import { useInvalidate } from 'shared/hooks';
+import { useInvalidate, useKeysAvailable } from 'shared/hooks';
 import { isModuleCSM } from 'consts';
 import { type AddKeysFormNetworkData } from './types';
 
@@ -60,16 +60,18 @@ const useAddKeysFormNetworkData: NetworkData<AddKeysFormNetworkData> = () => {
   const { data: operatorInfo, isPending: isOperatorInfoLoading } =
     useOperatorInfo(nodeOperatorId);
 
-  // const { data: nonWithdrawnKeys } = useNonWithdrawnKeysCount(`${nodeOperatorId}`);
+  const nonWithdrawnKeys = operatorInfo
+    ? operatorInfo.totalAddedKeys - operatorInfo.totalWithdrawnKeys
+    : undefined;
 
-  // const { data: keysAvailable } = useKeysAvailable({
-  //   curveId,
-  //   nonWithdrawnKeys,
-  //   bond,
-  //   ethBalance,
-  //   stethBalance,
-  //   wstethBalance,
-  // });
+  const keysAvailable = useKeysAvailable({
+    curveId,
+    nonWithdrawnKeys,
+    bond,
+    ethBalance,
+    stethBalance,
+    wstethBalance,
+  });
 
   const invalidate = useInvalidate();
 
@@ -117,6 +119,7 @@ const useAddKeysFormNetworkData: NetworkData<AddKeysFormNetworkData> = () => {
       maxStakeEth,
       shareLimit,
       isPaused: status?.isPaused,
+      keysAvailable,
     } as AddKeysFormNetworkData,
     isPending,
     revalidate,

--- a/features/add-keys/add-keys/context/types.ts
+++ b/features/add-keys/add-keys/context/types.ts
@@ -7,6 +7,7 @@ import {
   TOKENS,
 } from '@lidofinance/lido-csm-sdk';
 import { DepositDataInputType } from 'shared/hook-form/deposit-data';
+import { KeysAvailable } from 'shared/hooks';
 
 export type AddKeysFormInputType = {
   token: TOKENS;
@@ -25,5 +26,5 @@ export type AddKeysFormNetworkData = {
   isPaused: boolean;
   maxStakeEth: bigint;
   shareLimit?: ShareLimitInfo;
-  // keysAvailable: KeysAvailable;
+  keysAvailable?: KeysAvailable;
 };

--- a/features/add-keys/add-keys/context/use-add-keys-validation.ts
+++ b/features/add-keys/add-keys/context/use-add-keys-validation.ts
@@ -59,7 +59,7 @@ export const useAddKeysValidation = () => {
             depositData,
             sdk,
             keysLimit: curveParameters?.keysLimit,
-            currentActiveKeys:
+            nonWithdrawnKeys:
               operatorInfo &&
               operatorInfo.totalAddedKeys - operatorInfo.totalWithdrawnKeys,
           });

--- a/features/add-keys/add-keys/controls/keys-confirm.tsx
+++ b/features/add-keys/add-keys/controls/keys-confirm.tsx
@@ -4,13 +4,18 @@ import { SHARE_LIMIT_STATUS, useShareLimitStatus } from 'modules/web3';
 import { FC } from 'react';
 import { Stack } from 'shared/components';
 import { CheckboxHookForm } from 'shared/hook-form/controls';
+import { useDepositDataValid } from 'shared/hook-form/deposit-data';
 
 export const KeysConfirm: FC = () => {
   const { data: status } = useShareLimitStatus();
+  const isDepositDataValid = useDepositDataValid();
 
   return (
     <Stack align={isModuleCM ? 'center' : 'start'}>
-      <CheckboxHookForm fieldName="confirmKeysReady" />
+      <CheckboxHookForm
+        fieldName="confirmKeysReady"
+        disabled={!isDepositDataValid}
+      />
       {isModuleCM ? (
         <Text size="xxs" color="secondary" as="div">
           I confirm that my nodes are synced, running, and ready for the

--- a/features/add-keys/add-keys/controls/keys-limit-warning.tsx
+++ b/features/add-keys/add-keys/controls/keys-limit-warning.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { KeysLimitWarning as KeysLimitWarningBlock } from 'shared/components';
+import { useAddKeysFormData } from '../context';
+
+export const KeysLimitWarning: FC = () => {
+  const { curveParameters, operatorInfo } = useAddKeysFormData();
+
+  return (
+    <KeysLimitWarningBlock
+      keysLimit={curveParameters?.keysLimit}
+      nonWithdrawnKeys={
+        operatorInfo
+          ? operatorInfo.totalAddedKeys - operatorInfo.totalWithdrawnKeys
+          : undefined
+      }
+    />
+  );
+};

--- a/features/add-keys/add-keys/controls/token-select.tsx
+++ b/features/add-keys/add-keys/controls/token-select.tsx
@@ -6,7 +6,7 @@ import { BOND_EXCESS, BOND_INSUFFICIENT } from 'consts/text';
 import { PATH } from 'consts/urls';
 import {
   FormTitle,
-  // KeysAvailable,
+  KeysAvailable,
   MatomoLink,
   Stack,
   TitledAmount,
@@ -17,13 +17,8 @@ import { LocalLink } from 'shared/navigate';
 import { useAddKeysFormData } from '../context';
 
 export const TokenSelect: React.FC = () => {
-  const {
-    ethBalance,
-    stethBalance,
-    wstethBalance,
-    // keysAvailable,
-    bond,
-  } = useAddKeysFormData(true);
+  const { ethBalance, stethBalance, wstethBalance, keysAvailable, bond } =
+    useAddKeysFormData(true);
 
   return (
     <>
@@ -54,19 +49,28 @@ export const TokenSelect: React.FC = () => {
           [TOKENS.eth]: (
             <Stack direction="column">
               <TokenAmount token={TOKENS.eth} amount={ethBalance} />
-              {/* <KeysAvailable {...keysAvailable?.ETH} token={TOKENS.ETH} /> */}
+              <KeysAvailable
+                {...keysAvailable?.[TOKENS.eth]}
+                token={TOKENS.eth}
+              />
             </Stack>
           ),
           [TOKENS.steth]: (
             <Stack direction="column">
               <TokenAmount token={TOKENS.steth} amount={stethBalance} />
-              {/* <KeysAvailable {...keysAvailable?.STETH} token={TOKENS.STETH} /> */}
+              <KeysAvailable
+                {...keysAvailable?.[TOKENS.steth]}
+                token={TOKENS.steth}
+              />
             </Stack>
           ),
           [TOKENS.wsteth]: (
             <Stack direction="column">
               <TokenAmount token={TOKENS.wsteth} amount={wstethBalance} />
-              {/* <KeysAvailable {...keysAvailable?.WSTETH} token={TOKENS.WSTETH} /> */}
+              <KeysAvailable
+                {...keysAvailable?.[TOKENS.wsteth]}
+                token={TOKENS.wsteth}
+              />
             </Stack>
           ),
         }}

--- a/features/claim-type/claim-ics-form/claim-ics-success.tsx
+++ b/features/claim-type/claim-ics-form/claim-ics-success.tsx
@@ -50,10 +50,10 @@ export const ClaimIcsSuccess: FC = () => {
           Congratulations!
         </Text>
         <Text size="xs">
-          You have claimed the Identified Community Staker operator type
+          You have claimed the Identified Community Staker operator type.
           <br />
           You can see the new parameters for your Node Operator by clicking the
-          ICS badge at the top of the screen
+          ICS badge at the top of the screen.
         </Text>
       </Stack>
       <StyledButton fullwidth onClick={fire}>

--- a/features/create-node-operator/submit-keys-form/context/submit-keys-data-provider.tsx
+++ b/features/create-node-operator/submit-keys-form/context/submit-keys-data-provider.tsx
@@ -20,7 +20,11 @@ import {
   NetworkData,
   useFormData,
 } from 'shared/hook-form/form-controller';
-import { useCreateCurveId, useInvalidate } from 'shared/hooks';
+import {
+  useCreateCurveId,
+  useInvalidate,
+  useKeysAvailable,
+} from 'shared/hooks';
 import { type SubmitKeysFormNetworkData } from './types';
 
 const useSubmitKeysFormNetworkData: NetworkData<
@@ -56,12 +60,12 @@ const useSubmitKeysFormNetworkData: NetworkData<
 
   const { data: shareLimitStatus } = useShareLimitStatus();
 
-  // const { data: keysAvailable } = useKeysAvailable({
-  //   curveId,
-  //   ethBalance,
-  //   stethBalance,
-  //   wstethBalance,
-  // });
+  const keysAvailable = useKeysAvailable({
+    curveId,
+    ethBalance,
+    stethBalance,
+    wstethBalance,
+  });
 
   const invalidate = useInvalidate();
 
@@ -106,7 +110,7 @@ const useSubmitKeysFormNetworkData: NetworkData<
       maxStakeEth,
       shareLimit,
       shareLimitStatus,
-      // keysAvailable,
+      keysAvailable,
     } as SubmitKeysFormNetworkData,
     isPending,
     revalidate,

--- a/features/create-node-operator/submit-keys-form/context/types.ts
+++ b/features/create-node-operator/submit-keys-form/context/types.ts
@@ -6,6 +6,7 @@ import {
   TOKENS,
 } from '@lidofinance/lido-csm-sdk';
 import { DepositDataInputType } from 'shared/hook-form/deposit-data';
+import { KeysAvailable } from 'shared/hooks';
 import { Address } from 'viem';
 
 export type SubmitKeysFormInputType = {
@@ -31,5 +32,5 @@ export type SubmitKeysFormNetworkData = {
   proof?: Proof;
   shareLimit: ShareLimitInfo;
   shareLimitStatus: ShareLimitStatus;
-  // keysAvailable: KeysAvailable;
+  keysAvailable?: KeysAvailable;
 };

--- a/features/create-node-operator/submit-keys-form/controls/keys-confirm.tsx
+++ b/features/create-node-operator/submit-keys-form/controls/keys-confirm.tsx
@@ -2,15 +2,20 @@ import { Text } from '@lidofinance/lido-ui';
 import { FC } from 'react';
 import { Stack } from 'shared/components';
 import { CheckboxHookForm } from 'shared/hook-form/controls';
+import { useDepositDataValid } from 'shared/hook-form/deposit-data';
 import { useSubmitKeysFormData } from '../context';
 import { SHARE_LIMIT_STATUS } from 'modules/web3';
 
 export const KeysConfirm: FC = () => {
   const { shareLimitStatus } = useSubmitKeysFormData();
+  const isDepositDataValid = useDepositDataValid();
 
   return (
     <Stack align="start">
-      <CheckboxHookForm fieldName="confirmKeysReady" />
+      <CheckboxHookForm
+        fieldName="confirmKeysReady"
+        disabled={!isDepositDataValid}
+      />
       <Text size="xxs" color="secondary" as="div">
         I confirm that:
         <ul>

--- a/features/create-node-operator/submit-keys-form/controls/keys-limit-warning.tsx
+++ b/features/create-node-operator/submit-keys-form/controls/keys-limit-warning.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+import { KeysLimitWarning as KeysLimitWarningBlock } from 'shared/components';
+import { useSubmitKeysFormData } from '../context';
+
+export const KeysLimitWarning: FC = () => {
+  const { curveParameters } = useSubmitKeysFormData();
+
+  return (
+    <KeysLimitWarningBlock
+      keysLimit={curveParameters?.keysLimit}
+      nonWithdrawnKeys={0}
+    />
+  );
+};

--- a/features/create-node-operator/submit-keys-form/controls/token-select.tsx
+++ b/features/create-node-operator/submit-keys-form/controls/token-select.tsx
@@ -4,7 +4,7 @@ import { MATOMO_CLICK_EVENTS_TYPES } from 'consts/matomo-click-events';
 import { PATH } from 'consts/urls';
 import {
   FormTitle,
-  // KeysAvailable,
+  KeysAvailable,
   MatomoLink,
   Stack,
   TokenAmount,
@@ -15,7 +15,8 @@ import { useSubmitKeysFormData } from '../context';
 import { TOKENS } from '@lidofinance/lido-csm-sdk';
 
 export const TokenSelect: React.FC = () => {
-  const { ethBalance, stethBalance, wstethBalance } = useSubmitKeysFormData();
+  const { ethBalance, stethBalance, wstethBalance, keysAvailable } =
+    useSubmitKeysFormData();
 
   return (
     <>
@@ -46,19 +47,28 @@ export const TokenSelect: React.FC = () => {
           [TOKENS.eth]: (
             <Stack direction="column">
               <TokenAmount token={TOKENS.eth} amount={ethBalance} />
-              {/* <KeysAvailable {...keysAvailable?.ETH} token={TOKENS.eth} /> */}
+              <KeysAvailable
+                {...keysAvailable?.[TOKENS.eth]}
+                token={TOKENS.eth}
+              />
             </Stack>
           ),
           [TOKENS.steth]: (
             <Stack direction="column">
               <TokenAmount token={TOKENS.steth} amount={stethBalance} />
-              {/* <KeysAvailable {...keysAvailable?.STETH} token={TOKENS.steth} /> */}
+              <KeysAvailable
+                {...keysAvailable?.[TOKENS.steth]}
+                token={TOKENS.steth}
+              />
             </Stack>
           ),
           [TOKENS.wsteth]: (
             <Stack direction="column">
               <TokenAmount token={TOKENS.wsteth} amount={wstethBalance} />
-              {/* <KeysAvailable {...keysAvailable?.WSTETH} token={TOKENS.wsteth} /> */}
+              <KeysAvailable
+                {...keysAvailable?.[TOKENS.wsteth]}
+                token={TOKENS.wsteth}
+              />
             </Stack>
           ),
         }}

--- a/features/create-node-operator/submit-keys-form/submit-keys-form.tsx
+++ b/features/create-node-operator/submit-keys-form/submit-keys-form.tsx
@@ -11,6 +11,7 @@ import { AmountInput } from './controls/amount-input';
 import { CustomAddressesSection } from './controls/custom-addresses-section';
 import { KeysConfirm } from './controls/keys-confirm';
 import { KeysInput } from './controls/keys-input';
+import { KeysLimitWarning } from './controls/keys-limit-warning';
 import { ReferrerInput } from './controls/referrer-input';
 import { SubmitButton } from './controls/submit-button';
 import { TokenSelect } from './controls/token-select';
@@ -25,6 +26,7 @@ export const SubmitKeysForm: FC = memo(() => (
           <HeaderOperatorTypeButton />
           <Form>
             <TokenSelect />
+            <KeysLimitWarning />
             <KeysInput />
             <AmountInput />
             <KeysConfirm />

--- a/shared/alerts/components/alert-normalize-queue.tsx
+++ b/shared/alerts/components/alert-normalize-queue.tsx
@@ -9,7 +9,7 @@ export const AlertNomalizeQueue: FC = () => (
   <Alert title="You have unqueued keys">
     <p>
       You have keys that were not included in the deposit queue. To include them
-      in the queue - upload new keys, or normalize the queue
+      in the queue - upload new keys, or normalize the queue.
     </p>
     <br />
     <LocalLink

--- a/shared/components/counter/counter.tsx
+++ b/shared/components/counter/counter.tsx
@@ -6,14 +6,20 @@ type CounterProps = {
   count: number | undefined;
   warning?: boolean;
   type?: COUNTER_VARIANTS;
+  'data-testid'?: string;
 };
 
-export const Counter: FC<CounterProps> = ({ warning, count, type }) =>
+export const Counter: FC<CounterProps> = ({
+  warning,
+  count,
+  type,
+  'data-testid': dataTestid = 'navCounter',
+}) =>
   count ? (
     <InverseThemeProvider>
       <CounterStyle
         $variant={warning ? 'warning' : type}
-        data-testid="navCounter"
+        data-testid={dataTestid}
       >
         {count}
       </CounterStyle>

--- a/shared/components/index.ts
+++ b/shared/components/index.ts
@@ -19,6 +19,7 @@ export { FormBlock } from './form-block/form-block';
 export { IconTooltip } from './icon-tooltip/icon-tooltip';
 export { StepIndicator } from './step-indicator/step-indicator';
 export { KeysAvailable } from './keys-available/keys-available';
+export { KeysLimitWarning } from './keys-limit-warning/keys-limit-warning';
 export { YouWillReceive } from './you-will-receive/you-will-receive';
 export { InverseThemeProvider } from './inverse-theme-provider/inverse-theme-provider';
 export * from './logos/logos';

--- a/shared/components/input-amount/styles.tsx
+++ b/shared/components/input-amount/styles.tsx
@@ -1,7 +1,7 @@
 import { Input } from '@lidofinance/lido-ui';
 import styled from 'styled-components';
 
-export const StyledInput = styled(Input)`
+export const StyledInput = styled(Input).attrs({ spellCheck: false })`
   > span:has(:disabled) {
     background: var(--lido-color-accentControlBg);
   }

--- a/shared/components/keys-limit-warning/keys-limit-warning.tsx
+++ b/shared/components/keys-limit-warning/keys-limit-warning.tsx
@@ -1,0 +1,32 @@
+import { KEYS_UPLOAD_TX_LIMIT } from 'consts';
+import { FC } from 'react';
+import { WarningBlock } from '../warning-block/warning-block';
+import { pluralKeys } from 'utils';
+
+type Props = {
+  keysLimit?: number;
+  nonWithdrawnKeys?: number;
+};
+
+export const KeysLimitWarning: FC<Props> = ({
+  keysLimit,
+  nonWithdrawnKeys,
+}) => {
+  if (keysLimit === undefined || nonWithdrawnKeys === undefined) {
+    return null;
+  }
+
+  const gap = keysLimit - nonWithdrawnKeys;
+
+  if (gap >= KEYS_UPLOAD_TX_LIMIT) {
+    return null;
+  }
+
+  return (
+    <WarningBlock type="warning" data-testid="keysLimitWarning">
+      {gap <= 0
+        ? "Keys limit reached. New keys can't be uploaded until some of the current keys are withdrawn."
+        : `Approaching the keys limit. Only ${gap} more ${pluralKeys({ value: gap })} can be uploaded.`}
+    </WarningBlock>
+  );
+};

--- a/shared/components/parameters-list/parameters.tsx
+++ b/shared/components/parameters-list/parameters.tsx
@@ -103,7 +103,7 @@ const ALL_PARAMETERS: Parameter[] = [
   },
   {
     title: 'Keys limit',
-    help: 'A maximum number of active keys a Node Operator can have',
+    help: 'A maximum number of non-withdrawn keys a Node Operator can upload',
     render: (parameters) => formatKeysLimit(parameters?.keysLimit),
   },
   {

--- a/shared/components/status-comment/comments.tsx
+++ b/shared/components/status-comment/comments.tsx
@@ -61,9 +61,9 @@ export const CommentUnbondedNonQueued: FC = () => (
 
 export const CommentNonQueued: FC = () => (
   <>
-    If you have <b>Unbonded</b> keys — resolve the issues with them <br />
+    If you have <b>Unbonded</b> keys — resolve the issues with them. <br />
     If there are no <b>Unbonded</b> keys — put this key back to the queue (
-    <LocalLink href={PATH.KEYS_NORMALIZE}>Normalize queue</LocalLink>)
+    <LocalLink href={PATH.KEYS_NORMALIZE}>Normalize queue</LocalLink>).
   </>
 );
 

--- a/shared/components/warning-block/warning-block.tsx
+++ b/shared/components/warning-block/warning-block.tsx
@@ -1,12 +1,11 @@
-import { FC, PropsWithChildren } from 'react';
+import { FC, HTMLAttributes, PropsWithChildren } from 'react';
 import { WarningBlockStyle, NoteTypeStyle, BlockVariant } from './style';
 
 // TODO: refactor
-export const WarningBlock: FC<PropsWithChildren<{ type?: BlockVariant }>> = ({
-  children,
-  type = 'warning',
-}) => (
-  <WarningBlockStyle $variant={type}>
+export const WarningBlock: FC<
+  PropsWithChildren<{ type?: BlockVariant } & HTMLAttributes<HTMLDivElement>>
+> = ({ children, type = 'warning', ...props }) => (
+  <WarningBlockStyle $variant={type} {...props}>
     <NoteTypeStyle>{type}:</NoteTypeStyle> {children}
   </WarningBlockStyle>
 );

--- a/shared/hook-form/controls/deposit-data-hook-form.tsx
+++ b/shared/hook-form/controls/deposit-data-hook-form.tsx
@@ -24,8 +24,11 @@ export const DepositDataHookForm: FC = () => {
   });
   const error = errors.rawDepositData || errors.depositData;
 
-  const a = errors['depositData']?.types;
-  const errorsCount = hasKeys && a ? Object.keys(a).length : 0;
+  const depositDataErrorTypes = errors['depositData']?.types;
+  const errorsCount =
+    hasKeys && depositDataErrorTypes
+      ? Object.keys(depositDataErrorTypes).length
+      : 0;
 
   const hasErrorHighlight = isValidationErrorTypeValidate(error?.type);
   // allows to show error state without message
@@ -44,7 +47,13 @@ export const DepositDataHookForm: FC = () => {
             },
             {
               title: 'Parsed',
-              extra: <Counter count={errorsCount} warning />,
+              extra: (
+                <Counter
+                  count={errorsCount}
+                  warning
+                  data-testid="depositDataErrorsCounter"
+                />
+              ),
               disabled: !hasKeys,
               content: <DepositDataParsed />,
             },

--- a/shared/hook-form/deposit-data/deposit-data-input.tsx
+++ b/shared/hook-form/deposit-data/deposit-data-input.tsx
@@ -28,6 +28,7 @@ export const DepositDataInput: FC<DepositKeysInputHookFormProps> = ({
         disabled={props.disabled || field.disabled}
         label={label}
         rows={6}
+        spellCheck={false}
         fullwidth
       />
       <Placeholder>

--- a/shared/hook-form/deposit-data/deposit-data-parsed.tsx
+++ b/shared/hook-form/deposit-data/deposit-data-parsed.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@lidofinance/lido-ui';
+import { DATA_UNAVAILABLE } from 'consts';
 import { useSmSDK } from 'modules/web3';
 import { FC, useCallback } from 'react';
 import { useFormContext, useFormState, useWatch } from 'react-hook-form';
@@ -72,7 +73,10 @@ export const DepositDataParsed: FC = () => {
         return (
           <TableRow key={pubkey} data-testid="deposit-data-row">
             <DataCell $error={hasError} data-testid="deposit-data-pubkey">
-              <Pubkey pubkey={pubkey} color={hasError ? 'error' : 'default'} />
+              <Pubkey
+                pubkey={pubkey || DATA_UNAVAILABLE}
+                color={hasError ? 'error' : 'default'}
+              />
             </DataCell>
             <DataCell $error={hasError} data-testid="deposit-data-index">
               #{index + 1}

--- a/shared/hook-form/deposit-data/index.ts
+++ b/shared/hook-form/deposit-data/index.ts
@@ -3,4 +3,5 @@ export * from './deposit-data-input';
 export * from './deposit-data-parameters';
 export * from './deposit-data-parsed';
 export * from './styles';
+export * from './use-deposit-data-valid';
 export * from './use-parse-deposit-data';

--- a/shared/hook-form/deposit-data/use-deposit-data-valid.ts
+++ b/shared/hook-form/deposit-data/use-deposit-data-valid.ts
@@ -1,0 +1,18 @@
+import { useFormState, useWatch } from 'react-hook-form';
+import { DepositDataInputType } from './use-parse-deposit-data';
+
+// Deposit data is ready to confirm only when at least one key is parsed and
+// neither the raw input nor the parsed keys carry a validation error.
+export const useDepositDataValid = (): boolean => {
+  const [depositData] = useWatch<DepositDataInputType, ['depositData']>({
+    name: ['depositData'],
+  });
+
+  const { errors } = useFormState<DepositDataInputType>({
+    name: ['depositData', 'rawDepositData'],
+  });
+
+  const hasError = !!(errors.rawDepositData || errors.depositData);
+
+  return depositData.length > 0 && !hasError;
+};

--- a/shared/hook-form/validation/validate-deposit-data.ts
+++ b/shared/hook-form/validation/validate-deposit-data.ts
@@ -1,20 +1,21 @@
 import type { DepositData, DepositDataSDK } from '@lidofinance/lido-csm-sdk';
 import { groupBy, mapValues, uniqBy } from 'lodash';
 import { KEYS_UPLOAD_TX_LIMIT } from 'consts/keys';
+import { pluralKeys } from 'utils';
 import { ValidationError } from './validation-error';
 
 type ValidateDepositDataProps = {
   depositData: DepositData[];
   sdk: DepositDataSDK;
   keysLimit?: number;
-  currentActiveKeys?: number;
+  nonWithdrawnKeys?: number;
 };
 
 export const validateDepositData = async ({
   depositData,
   sdk,
   keysLimit,
-  currentActiveKeys,
+  nonWithdrawnKeys,
 }: ValidateDepositDataProps) => {
   if (!depositData?.length) return;
 
@@ -52,13 +53,15 @@ export const validateDepositData = async ({
   if (keysLimit !== undefined) {
     const keysCount = depositData.length;
 
-    if (currentActiveKeys !== undefined) {
-      // Add-keys flow: check total keys after adding
-      if (currentActiveKeys + keysCount > keysLimit) {
-        const availableSlots = Math.max(keysLimit - currentActiveKeys, 0);
+    if (nonWithdrawnKeys !== undefined) {
+      // Add-keys flow: check total non-withdrawn keys after adding
+      if (nonWithdrawnKeys + keysCount > keysLimit) {
+        const availableSlots = Math.max(keysLimit - nonWithdrawnKeys, 0);
         throw new ValidationError(
           'depositData',
-          `Keys limit exceeded. Allowed keys count to submit: ${availableSlots}.`,
+          availableSlots === 0
+            ? `Keys limit of ${keysLimit} non-withdrawn ${pluralKeys({ value: keysLimit })} reached. New keys can't be uploaded.`
+            : `Keys limit of ${keysLimit} non-withdrawn ${pluralKeys({ value: keysLimit })} exceeded. Only ${availableSlots} more ${pluralKeys({ value: availableSlots })} can be uploaded.`,
         );
       }
     } else {
@@ -66,7 +69,7 @@ export const validateDepositData = async ({
       if (keysCount > keysLimit) {
         throw new ValidationError(
           'depositData',
-          `Keys limit exceeded. Allowed keys count to submit: ${keysLimit}.`,
+          `Keys limit exceeded. Up to ${pluralKeys({ value: keysLimit, showValue: true })} can be uploaded.`,
         );
       }
     }

--- a/shared/hooks/use-keys-available.ts
+++ b/shared/hooks/use-keys-available.ts
@@ -19,9 +19,11 @@ export type KeysAvailable = Record<TOKENS, AvailableForToken>;
 
 /**
  * How many keys the wallet balances can fund, per token, with the bond amount
- * each option would cost. Informational only — the actual key count comes from
- * the uploaded deposit data. The curve math is reconstructed client-side from
- * `bondConfig` (see `utils/bond-curve`); no extra on-chain reads.
+ * each option would cost. Capped by the per-transaction upload limit and the
+ * curve's `keysLimit` (max non-withdrawn keys). Informational only — the
+ * actual key count comes from the uploaded deposit data. The curve math is
+ * reconstructed client-side from `bondConfig` (see `utils/bond-curve`); no
+ * extra on-chain reads.
  */
 export const useKeysAvailable = ({
   curveId,
@@ -36,7 +38,13 @@ export const useKeysAvailable = ({
 
   return useMemo(() => {
     const intervals = curve?.bondConfig;
-    if (!intervals || intervals.length === 0 || !rates) {
+    const keysLimit = curve?.keysLimit;
+    if (
+      !intervals ||
+      intervals.length === 0 ||
+      keysLimit === undefined ||
+      !rates
+    ) {
       return undefined;
     }
 
@@ -53,6 +61,7 @@ export const useKeysAvailable = ({
       const limited = Math.min(
         fundable,
         nonWithdrawnKeys + KEYS_UPLOAD_TX_LIMIT,
+        keysLimit,
       );
 
       const count = Math.max(limited - nonWithdrawnKeys, 0);

--- a/shared/hooks/use-keys-available.ts
+++ b/shared/hooks/use-keys-available.ts
@@ -1,13 +1,9 @@
 import { useMemo } from 'react';
-import {
-  TOKENS,
-  BondBalance,
-  KeyNumberValueInterval,
-} from '@lidofinance/lido-csm-sdk';
-import { ONE_ETH } from 'consts/tokens';
-import { KEYS_UPLOAD_TX_LIMIT } from 'consts';
+import { BondBalance, TOKENS } from '@lidofinance/lido-csm-sdk';
+import { KEYS_UPLOAD_TX_LIMIT, ONE_ETH } from 'consts';
 import { useExchangeRate } from 'shared/hooks';
 import { useCurveParameters } from 'modules/web3/hooks/use-curve-parameters';
+import { bondForKeys, convert, maxKeysForBond } from 'utils';
 
 type Props = {
   curveId?: bigint;
@@ -18,158 +14,67 @@ type Props = {
   wstethBalance?: bigint;
 };
 
-export type KeysAvailable = Record<TOKENS, ReturnType<typeof calc>>;
+type AvailableForToken = { count: number; amount: bigint };
+export type KeysAvailable = Record<TOKENS, AvailableForToken>;
 
+/**
+ * How many keys the wallet balances can fund, per token, with the bond amount
+ * each option would cost. Informational only — the actual key count comes from
+ * the uploaded deposit data. The curve math is reconstructed client-side from
+ * `bondConfig` (see `utils/bond-curve`); no extra on-chain reads.
+ */
 export const useKeysAvailable = ({
   curveId,
-  nonWithdrawnKeys,
   bond,
+  nonWithdrawnKeys = 0,
   ethBalance,
   stethBalance,
   wstethBalance,
-}: Props) => {
+}: Props): KeysAvailable | undefined => {
   const { data: curve } = useCurveParameters(curveId);
   const { data: rates } = useExchangeRate();
 
   return useMemo(() => {
-    if (!curve || !rates) {
+    const intervals = curve?.bondConfig;
+    if (!intervals || intervals.length === 0 || !rates) {
       return undefined;
     }
 
-    // Extract bond config from the parameters structure
-    const bondConfig = curve.bondConfig;
-    if (!bondConfig || bondConfig.length === 0) {
-      return undefined;
-    }
+    const currentBond = bond?.current ?? 0n;
+
+    const calc = (
+      balance: bigint | undefined,
+      rate: bigint,
+    ): AvailableForToken => {
+      if (balance === undefined) return { count: 0, amount: 0n };
+
+      const balanceInSteth = convert(balance, rate);
+      const fundable = maxKeysForBond(intervals, currentBond + balanceInSteth);
+      const limited = Math.min(
+        fundable,
+        nonWithdrawnKeys + KEYS_UPLOAD_TX_LIMIT,
+      );
+
+      const count = Math.max(limited - nonWithdrawnKeys, 0);
+      const neededSteth = bondForKeys(intervals, limited) - currentBond;
+      const amount =
+        neededSteth > 0n ? convert(neededSteth, ONE_ETH, rate) : 0n;
+
+      return { count, amount };
+    };
 
     return {
-      [TOKENS.eth]: calc(
-        ethBalance,
-        rates[TOKENS.eth],
-        bond?.current,
-        KEYS_UPLOAD_TX_LIMIT,
-        nonWithdrawnKeys,
-        bondConfig,
-      ),
-      [TOKENS.steth]: calc(
-        stethBalance,
-        rates[TOKENS.steth],
-        bond?.current,
-        KEYS_UPLOAD_TX_LIMIT,
-        nonWithdrawnKeys,
-        bondConfig,
-      ),
-      [TOKENS.wsteth]: calc(
-        wstethBalance,
-        rates[TOKENS.wsteth],
-        bond?.current,
-        KEYS_UPLOAD_TX_LIMIT,
-        nonWithdrawnKeys,
-        bondConfig,
-      ),
+      [TOKENS.eth]: calc(ethBalance, rates[TOKENS.eth]),
+      [TOKENS.steth]: calc(stethBalance, rates[TOKENS.steth]),
+      [TOKENS.wsteth]: calc(wstethBalance, rates[TOKENS.wsteth]),
     } as KeysAvailable;
   }, [
     curve,
     rates,
-    ethBalance,
     bond,
     nonWithdrawnKeys,
+    ethBalance,
     stethBalance,
     wstethBalance,
   ]);
-};
-
-const calc = (
-  balance?: bigint,
-  rate?: bigint,
-  bond = 0n,
-  keysUploadLimit?: number,
-  nonWithdrawnKeys = 0,
-  bondConfig?: KeyNumberValueInterval[],
-) => {
-  if (keysUploadLimit === undefined || !bondConfig || !balance || !rate) return;
-
-  const amountInSTETH = convert(balance, rate, ONE_ETH);
-  const totalAmount = amountInSTETH + bond;
-
-  const maxCount = getMaxKeys(bondConfig, totalAmount);
-
-  const limitedMaxCount = Math.min(
-    maxCount,
-    nonWithdrawnKeys + keysUploadLimit,
-  );
-
-  const keysAmount = getAmountByKeys(bondConfig, limitedMaxCount) - bond;
-  const count = Math.max(limitedMaxCount - nonWithdrawnKeys, 0);
-  const amount = keysAmount > 0n ? convert(keysAmount, ONE_ETH, rate) : 0n;
-
-  return {
-    count,
-    amount,
-  };
-};
-
-const convert = (value: bigint, rate: bigint, base: bigint) => {
-  return (value * rate) / base;
-};
-
-const getMaxKeys = (bondConfig: KeyNumberValueInterval[], amount: bigint) => {
-  let currentAmount = 0n;
-  let currentKeys = 0;
-
-  for (let i = 0; i < bondConfig.length; i++) {
-    const interval = bondConfig[i];
-    const nextInterval = bondConfig[i + 1];
-
-    // Determine the end of this interval
-    const intervalEnd = nextInterval ? nextInterval.minKeyNumber : Infinity;
-
-    // Calculate how many keys we can afford in this interval
-    const remainingAmount = amount - currentAmount;
-    const keysInInterval = Number(remainingAmount / interval.value);
-
-    if (currentKeys + keysInInterval >= intervalEnd) {
-      // Move to next interval
-      const keysToAdd = intervalEnd - currentKeys;
-      currentAmount += BigInt(keysToAdd) * interval.value;
-      currentKeys = intervalEnd;
-
-      if (currentAmount >= amount) {
-        return currentKeys;
-      }
-    } else {
-      // We can't afford to fill this interval completely
-      return currentKeys + keysInInterval;
-    }
-  }
-
-  return currentKeys;
-};
-
-const getAmountByKeys = (
-  bondConfig: KeyNumberValueInterval[],
-  count: number,
-) => {
-  let totalAmount = 0n;
-  let currentKeys = 0;
-
-  for (let i = 0; i < bondConfig.length && currentKeys < count; i++) {
-    const interval = bondConfig[i];
-    const nextInterval = bondConfig[i + 1];
-
-    // Determine the end of this interval
-    const intervalEnd = nextInterval ? nextInterval.minKeyNumber : count;
-
-    // Calculate how many keys to process in this interval
-    const keysInThisInterval = Math.min(
-      count - currentKeys,
-      intervalEnd - currentKeys,
-    );
-
-    // Add the cost for these keys
-    totalAmount += BigInt(keysInThisInterval) * interval.value;
-    currentKeys += keysInThisInterval;
-  }
-
-  return totalAmount;
 };

--- a/tests/cm-widget/pages/tabs/keys/submit.page.ts
+++ b/tests/cm-widget/pages/tabs/keys/submit.page.ts
@@ -10,13 +10,20 @@ export class SubmitPage {
   formBlock: Locator;
   rawDepositData: Locator;
   confirmKeysReady: Locator;
+  confirmKeysReadyInput: Locator;
   submitKeysButton: Locator;
   amountInput: Locator;
   amountInputText: Locator;
   validationInputError: Locator;
 
+  // Tabs
+  jsonTab: Locator;
+  parsedTab: Locator;
+  parametersTab: Locator;
+
   // Parsed tab
   depositDataRow: Locator;
+  parsedTabCounter: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -26,6 +33,9 @@ export class SubmitPage {
     this.confirmKeysReady = this.formBlock
       .locator('label:has([name="confirmKeysReady"])')
       .locator('svg');
+    this.confirmKeysReadyInput = this.formBlock.locator(
+      '[name="confirmKeysReady"]',
+    );
     this.submitKeysButton = this.formBlock
       .getByRole('button')
       .getByText('Submit keys');
@@ -35,8 +45,16 @@ export class SubmitPage {
       'input-message-error',
     );
 
+    // Tabs
+    this.jsonTab = this.formBlock.getByTestId('tab-button-JSON');
+    this.parsedTab = this.formBlock.getByTestId('tab-button-Parsed');
+    this.parametersTab = this.formBlock.getByTestId('tab-button-Parameters');
+
     // Parsed tab
     this.depositDataRow = this.formBlock.getByTestId('deposit-data-row');
+    this.parsedTabCounter = this.formBlock.getByTestId(
+      'depositDataErrorsCounter',
+    );
   }
 
   async open() {
@@ -47,8 +65,7 @@ export class SubmitPage {
 
   async selectTab(tabName: 'JSON' | 'Parsed' | 'Parameters') {
     return test.step(`Select "${tabName}" tab`, async () => {
-      const tab = this.formBlock.getByRole('button').getByText(tabName);
-      await tab.click();
+      await this.formBlock.getByTestId(`tab-button-${tabName}`).click();
     });
   }
 
@@ -60,6 +77,12 @@ export class SubmitPage {
     await test.step('Fill deposit key data', async () => {
       const value = JSON.stringify(keys);
       await this.rawDepositData.fill(value);
+    });
+  }
+
+  async fillRawKeys(raw: string) {
+    await test.step('Fill raw deposit key data', async () => {
+      await this.rawDepositData.fill(raw);
     });
   }
 

--- a/tests/cm-widget/tests/operatorWithValidator/keys/duplicatedKeys.spec.ts
+++ b/tests/cm-widget/tests/operatorWithValidator/keys/duplicatedKeys.spec.ts
@@ -51,10 +51,10 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'invalid signature',
+            'signature failed BLS verification',
           );
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'pubkey already exists as validator on CL',
+            'pubkey already exists as a validator on CL',
           );
         }
       },
@@ -100,7 +100,7 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toHaveText(
-            'pubkey already exists in cache',
+            'pubkey already submitted',
           );
         }
       },

--- a/tests/cm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
+++ b/tests/cm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
@@ -10,6 +10,7 @@ import {
 import { randomBytes } from 'node:crypto';
 import { generateWithdrawalCredentials } from '../../../../shared/helpers/accountData';
 import { PRESETS } from 'tests/cm-widget/config/walletSetup/walletPresets.state';
+import { SubmitPage } from 'tests/cm-widget/pages/tabs/keys/submit.page';
 
 test.use({ secretPhrase: PRESETS.ONLY_OPERATOR.secretPhrase });
 
@@ -20,6 +21,17 @@ const omitField = <K extends keyof DepositKey>(
   const { [field]: _removed, ...rest } = obj;
   return rest;
 };
+
+// Unparseable JSON keeps depositData empty, so the Parsed/Parameters tabs and
+// downstream controls must stay locked.
+const expectFormLocked = (submitPage: SubmitPage) =>
+  test.step('Verify Parsed/Parameters tabs and controls are disabled', async () => {
+    await expect(submitPage.parsedTab).toBeDisabled();
+    await expect(submitPage.parametersTab).toBeDisabled();
+    await expect(submitPage.amountInput).toBeDisabled();
+    await expect(submitPage.submitKeysButton).toBeDisabled();
+    await expect(submitPage.confirmKeysReadyInput).toBeDisabled();
+  });
 
 // Omitting any of these required fields makes the SDK parser reject the JSON
 // before per-key validation runs, surfacing a "missing required field" error.
@@ -54,6 +66,13 @@ test.describe(
       await expect(keysPage.submitPage.validationInputError).toContainText(
         'Invalid deposit data',
       );
+
+      await test.step('Verify Parsed tab is available with error counter', async () => {
+        await expect(keysPage.submitPage.parsedTab).toBeEnabled();
+        await expect(keysPage.submitPage.parametersTab).toBeEnabled();
+        await expect(keysPage.submitPage.parsedTabCounter).toHaveText('1');
+      });
+
       await keysPage.submitPage.selectTab('Parsed');
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
@@ -257,6 +276,48 @@ test.describe(
       },
     );
 
+    test('Should count only invalid keys when some keys are valid', async () => {
+      const keys = keysGeneratorService.generateKeys(3);
+      keys[0].amount = 1;
+      keys[2].amount = 1;
+
+      await keysPage.submitPage.fillKeys(keys);
+      await expect(keysPage.submitPage.validationInputError).toContainText(
+        'Invalid deposit data',
+      );
+
+      await test.step('Verify counter reflects only the invalid keys', async () => {
+        await expect(keysPage.submitPage.parsedTab).toBeEnabled();
+        await expect(keysPage.submitPage.parsedTabCounter).toHaveText('2');
+      });
+
+      await keysPage.submitPage.selectTab('Parsed');
+      await expect(keysPage.submitPage.depositDataRow).toHaveCount(3);
+
+      await test.step('Verify per-row error detection', async () => {
+        const rows = keysPage.submitPage.depositDataRow;
+        await expect(
+          rows.nth(0).getByTestId('deposit-data-error-detected'),
+        ).toHaveText('Yes');
+        await expect(
+          rows.nth(1).getByTestId('deposit-data-error-detected'),
+        ).toHaveText('No');
+        await expect(
+          rows.nth(2).getByTestId('deposit-data-error-detected'),
+        ).toHaveText('Yes');
+
+        await expect(
+          rows.nth(0).getByTestId('deposit-data-error'),
+        ).toContainText('amount is not equal to 32 ETH');
+        await expect(
+          rows.nth(1).getByTestId('deposit-data-error'),
+        ).toBeHidden();
+        await expect(
+          rows.nth(2).getByTestId('deposit-data-error'),
+        ).toContainText('amount is not equal to 32 ETH');
+      });
+    });
+
     requiredFields.forEach((propertyName) => {
       test(
         qase(
@@ -276,6 +337,8 @@ test.describe(
           await expect(keysPage.submitPage.validationInputError).toHaveText(
             `Item at index 0 is missing required field: ${propertyName}`,
           );
+
+          await expectFormLocked(keysPage.submitPage);
         },
       );
     });
@@ -299,6 +362,8 @@ test.describe(
           await expect(keysPage.submitPage.validationInputError).toHaveText(
             `Item at index 0 is missing required field: ${propertyName}`,
           );
+
+          await expectFormLocked(keysPage.submitPage);
         },
       );
     });
@@ -320,6 +385,8 @@ test.describe(
           await expect(keysPage.submitPage.validationInputError).toHaveText(
             `Item at index 2 is missing required field: ${propertyName}`,
           );
+
+          await expectFormLocked(keysPage.submitPage);
         },
       );
     });

--- a/tests/cm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
+++ b/tests/cm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
@@ -21,37 +21,16 @@ const omitField = <K extends keyof DepositKey>(
   return rest;
 };
 
-const invalidTextValidation: {
-  key: keyof DepositKey;
-  expectedError: string;
-}[] = [
-  {
-    key: 'withdrawal_credentials',
-    expectedError:
-      'withdrawal_credentials is not a valid stringinvalid signature',
-  },
-  {
-    key: 'amount',
-    expectedError: 'amount is not equal to 32 ethinvalid signature',
-  },
-  {
-    key: 'deposit_data_root',
-    expectedError: 'deposit_data_root is not a valid string',
-  },
-  {
-    key: 'deposit_message_root',
-    expectedError:
-      'deposit_message_root is not a valid stringinvalid signature',
-  },
-  {
-    key: 'fork_version',
-    expectedError: 'fork_version is not equal to 10000910',
-  },
-  {
-    key: 'pubkey',
-    expectedError: 'pubkey is not a valid stringinvalid signature',
-  },
-  { key: 'signature', expectedError: 'signature is not a valid string' },
+// Omitting any of these required fields makes the SDK parser reject the JSON
+// before per-key validation runs, surfacing a "missing required field" error.
+const requiredFields: (keyof DepositKey)[] = [
+  'withdrawal_credentials',
+  'amount',
+  'deposit_data_root',
+  'deposit_message_root',
+  'fork_version',
+  'pubkey',
+  'signature',
 ];
 
 test.describe(
@@ -79,7 +58,7 @@ test.describe(
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toHaveText(
-          'amount is not equal to 32 ethinvalid signature',
+          'amount is not equal to 32 ETHsignature failed BLS verification',
         );
       }
     });
@@ -96,7 +75,7 @@ test.describe(
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toHaveText(
-          'invalid signature',
+          'signature failed BLS verification',
         );
       }
     });
@@ -115,10 +94,10 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'invalid signature',
+            'signature failed BLS verification',
           );
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'pubkey is not valid string',
+            'pubkey is not a valid hex string',
           );
         }
       },
@@ -138,7 +117,7 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toHaveText(
-            'invalid signature',
+            'signature failed BLS verification',
           );
         }
       },
@@ -158,10 +137,10 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'invalid signature',
+            'signature failed BLS verification',
           );
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'deposit_message_root is not a valid string',
+            'deposit_message_root is not a valid hex string',
           );
         }
       },
@@ -182,7 +161,7 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toHaveText(
-            'withdrawal_credentials is not the Lido Withdrawal Vaultinvalid signature',
+            'withdrawal_credentials is not the Lido Withdrawal Vaultsignature failed BLS verification',
           );
         }
       },
@@ -201,7 +180,7 @@ test.describe(
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toHaveText(
-          'wrong key type: only 0x02 withdrawal credentials are supportedinvalid signature',
+          'wrong key type: only 0x02 withdrawal credentials are supportedsignature failed BLS verification',
         );
       }
     });
@@ -224,10 +203,10 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'invalid signature',
+            'signature failed BLS verification',
           );
           await expect(row.getByTestId('deposit-data-error')).toContainText(
-            'withdrawal_credentials is not a valid string',
+            'withdrawal_credentials is not a valid hex string',
           );
         }
       },
@@ -272,13 +251,13 @@ test.describe(
         await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
         for (const row of await keysPage.submitPage.depositDataRow.all()) {
           await expect(row.getByTestId('deposit-data-error')).toHaveText(
-            `network_name or eth2_network_name is not equal to ${widgetConfig.standConfig.networkConfig.chainName.toLowerCase()}`,
+            `network_name is not equal to ${widgetConfig.standConfig.networkConfig.chainName.toLowerCase()}`,
           );
         }
       },
     );
 
-    invalidTextValidation.forEach(({ key: propertyName, expectedError }) => {
+    requiredFields.forEach((propertyName) => {
       test(
         qase(
           104,
@@ -294,25 +273,14 @@ test.describe(
             newJson,
           );
 
-          await test.step('Verify invalid deposit data error is shown', async () => {
-            await expect(keysPage.submitPage.validationInputError).toHaveText(
-              'Invalid deposit data',
-            );
-          });
-
-          await test.step('Verify Parsed tab shows per-key error', async () => {
-            await keysPage.submitPage.selectTab('Parsed');
-            await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
-            const row = keysPage.submitPage.depositDataRow.first();
-            await expect(row.getByTestId('deposit-data-error')).toContainText(
-              expectedError,
-            );
-          });
+          await expect(keysPage.submitPage.validationInputError).toHaveText(
+            `Item at index 0 is missing required field: ${propertyName}`,
+          );
         },
       );
     });
 
-    invalidTextValidation.forEach(({ key: propertyName, expectedError }) => {
+    requiredFields.forEach((propertyName) => {
       test(
         qase(
           111,
@@ -328,25 +296,14 @@ test.describe(
             [newJson],
           );
 
-          await test.step('Verify invalid deposit data error is shown', async () => {
-            await expect(keysPage.submitPage.validationInputError).toHaveText(
-              'Invalid deposit data',
-            );
-          });
-
-          await test.step('Verify Parsed tab shows per-key error', async () => {
-            await keysPage.submitPage.selectTab('Parsed');
-            await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
-            const row = keysPage.submitPage.depositDataRow.first();
-            await expect(row.getByTestId('deposit-data-error')).toContainText(
-              expectedError,
-            );
-          });
+          await expect(keysPage.submitPage.validationInputError).toHaveText(
+            `Item at index 0 is missing required field: ${propertyName}`,
+          );
         },
       );
     });
 
-    invalidTextValidation.forEach(({ key: propertyName, expectedError }) => {
+    requiredFields.forEach((propertyName) => {
       test(
         qase(
           118,
@@ -360,27 +317,9 @@ test.describe(
 
           await keysPage.submitPage.fillKeys(keys);
 
-          await test.step('Verify invalid deposit data error is shown', async () => {
-            await expect(keysPage.submitPage.validationInputError).toHaveText(
-              'Invalid deposit data',
-            );
-          });
-
-          await test.step('Verify Parsed tab shows error only on key at index 2', async () => {
-            await keysPage.submitPage.selectTab('Parsed');
-            await expect(keysPage.submitPage.depositDataRow).toHaveCount(3);
-
-            const rows = await keysPage.submitPage.depositDataRow.all();
-            await expect(
-              rows[0].getByTestId('deposit-data-error'),
-            ).not.toBeVisible();
-            await expect(
-              rows[1].getByTestId('deposit-data-error'),
-            ).not.toBeVisible();
-            await expect(
-              rows[2].getByTestId('deposit-data-error'),
-            ).toContainText(expectedError);
-          });
+          await expect(keysPage.submitPage.validationInputError).toHaveText(
+            `Item at index 2 is missing required field: ${propertyName}`,
+          );
         },
       );
     });

--- a/tests/cm-widget/tests/operatorWithValidator/keys/validation.spec.ts
+++ b/tests/cm-widget/tests/operatorWithValidator/keys/validation.spec.ts
@@ -47,6 +47,20 @@ test.describe(
       },
     );
 
+    test('Should disable Parsed tab for unparseable json', async () => {
+      await keysPage.submitPage.fillRawKeys('{ this is not valid json');
+
+      await test.step('Verify parse error is shown', async () => {
+        await expect(keysPage.submitPage.validationInputError).toBeVisible();
+      });
+
+      await test.step('Verify Parsed/Parameters tabs and parsed data are unavailable', async () => {
+        await expect(keysPage.submitPage.parsedTab).toBeDisabled();
+        await expect(keysPage.submitPage.parametersTab).toBeDisabled();
+        await expect(keysPage.submitPage.depositDataRow).toHaveCount(0);
+      });
+    });
+
     test(
       qase(
         125,

--- a/tests/csm-widget/pages/tabs/keys/submit.page.ts
+++ b/tests/csm-widget/pages/tabs/keys/submit.page.ts
@@ -16,8 +16,14 @@ export class SubmitPage {
   amountInputText: Locator;
   validationInputError: Locator;
 
+  // Tabs
+  jsonTab: Locator;
+  parsedTab: Locator;
+  parametersTab: Locator;
+
   // Parsed tab
   depositDataRow: Locator;
+  parsedTabCounter: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -39,8 +45,16 @@ export class SubmitPage {
       'input-message-error',
     );
 
+    // Tabs
+    this.jsonTab = this.formBlock.getByTestId('tab-button-JSON');
+    this.parsedTab = this.formBlock.getByTestId('tab-button-Parsed');
+    this.parametersTab = this.formBlock.getByTestId('tab-button-Parameters');
+
     // Parsed tab
     this.depositDataRow = this.formBlock.getByTestId('deposit-data-row');
+    this.parsedTabCounter = this.formBlock.getByTestId(
+      'depositDataErrorsCounter',
+    );
   }
 
   async open() {
@@ -51,8 +65,7 @@ export class SubmitPage {
 
   async selectTab(tabName: 'JSON' | 'Parsed' | 'Parameters') {
     return test.step(`Select "${tabName}" tab`, async () => {
-      const tab = this.formBlock.getByRole('button').getByText(tabName);
-      await tab.click();
+      await this.formBlock.getByTestId(`tab-button-${tabName}`).click();
     });
   }
 
@@ -64,6 +77,12 @@ export class SubmitPage {
     await test.step('Fill deposit key data', async () => {
       const value = JSON.stringify(keys);
       await this.rawDepositData.fill(value);
+    });
+  }
+
+  async fillRawKeys(raw: string) {
+    await test.step('Fill raw deposit key data', async () => {
+      await this.rawDepositData.fill(raw);
     });
   }
 

--- a/tests/csm-widget/pages/tabs/keys/submit.page.ts
+++ b/tests/csm-widget/pages/tabs/keys/submit.page.ts
@@ -10,6 +10,7 @@ export class SubmitPage {
   formBlock: Locator;
   rawDepositData: Locator;
   confirmKeysReady: Locator;
+  confirmKeysReadyInput: Locator;
   submitKeysButton: Locator;
   amountInput: Locator;
   amountInputText: Locator;
@@ -26,6 +27,9 @@ export class SubmitPage {
     this.confirmKeysReady = this.formBlock
       .locator('label:has([name="confirmKeysReady"])')
       .locator('svg');
+    this.confirmKeysReadyInput = this.formBlock.locator(
+      '[name="confirmKeysReady"]',
+    );
     this.submitKeysButton = this.formBlock
       .getByRole('button')
       .getByText('Submit keys');

--- a/tests/csm-widget/tests/operatorWithValidator/bondRewards/addBond.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/bondRewards/addBond.spec.ts
@@ -22,7 +22,7 @@ test.describe('Bond & Rewards. Add bond.', async () => {
         await test.step('Verify bond balance', async () => {
           await expect(
             bondRewardsPage.addBond.titledAmount.locator('div').first(),
-          ).toContainText('Bond balance');
+          ).toContainText('Excess bond');
           const bondSummary = await csmSDK.getBondSummary(nodeOperatorId);
 
           await expect(bondRewardsPage.addBond.titledAmountBalance).toHaveText(

--- a/tests/csm-widget/tests/operatorWithValidator/bondRewards/addBond.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/bondRewards/addBond.spec.ts
@@ -32,7 +32,7 @@ test.describe('Bond & Rewards. Add bond.', async () => {
 
         await test.step('Verify text', async () => {
           const expectedText =
-            'Why you might need to add bond:Adding a bond serves as a voluntary security measure for your Node Operator to prevent your validators from becoming unbonded and being requested to exit in case of applied penaltiesSupplied bond will be stored as stETH, which also garners staking rewards';
+            'Why you might need to add bond:Adding a bond serves as a voluntary security measure for your Node Operator to prevent your validators from becoming unbonded and being requested to exit in case of applied penalties. Supplied bond will be stored as stETH, which also garners staking rewards.';
           await expect(bondRewardsPage.addBond.formInfoText).toContainText(
             expectedText,
           );

--- a/tests/csm-widget/tests/operatorWithValidator/keys/duplicatedKeys.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/keys/duplicatedKeys.spec.ts
@@ -44,10 +44,10 @@ test.describe('Operator with keys. Validation duplicated keys.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'invalid signature',
+          'signature failed BLS verification',
         );
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'pubkey already exists as validator on CL',
+          'pubkey already exists as a validator on CL',
         );
       }
     },
@@ -131,7 +131,7 @@ test.describe('Operator with keys. Validation duplicated keys.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'invalid signature',
+          'signature failed BLS verification',
         );
         await expect(row.getByTestId('deposit-data-error')).toContainText(
           'pubkey was previously submitted',

--- a/tests/csm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
@@ -26,6 +26,13 @@ test.describe('Operator with keys. Validation keys json.', async () => {
     await expect(keysPage.submitPage.validationInputError).toContainText(
       'Invalid deposit data',
     );
+
+    await test.step('Verify Parsed tab is available with error counter', async () => {
+      await expect(keysPage.submitPage.parsedTab).toBeEnabled();
+      await expect(keysPage.submitPage.parametersTab).toBeEnabled();
+      await expect(keysPage.submitPage.parsedTabCounter).toHaveText('1');
+    });
+
     await keysPage.submitPage.selectTab('Parsed');
     await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
     for (const row of await keysPage.submitPage.depositDataRow.all()) {
@@ -204,4 +211,44 @@ test.describe('Operator with keys. Validation keys json.', async () => {
       }
     },
   );
+
+  test('Should count only invalid keys when some keys are valid', async () => {
+    const keys = keysGeneratorService.generateKeys(3);
+    keys[0].amount = 1;
+    keys[2].amount = 1;
+
+    await keysPage.submitPage.fillKeys(keys);
+    await expect(keysPage.submitPage.validationInputError).toContainText(
+      'Invalid deposit data',
+    );
+
+    await test.step('Verify counter reflects only the invalid keys', async () => {
+      await expect(keysPage.submitPage.parsedTab).toBeEnabled();
+      await expect(keysPage.submitPage.parsedTabCounter).toHaveText('2');
+    });
+
+    await keysPage.submitPage.selectTab('Parsed');
+    await expect(keysPage.submitPage.depositDataRow).toHaveCount(3);
+
+    await test.step('Verify per-row error detection', async () => {
+      const rows = keysPage.submitPage.depositDataRow;
+      await expect(
+        rows.nth(0).getByTestId('deposit-data-error-detected'),
+      ).toHaveText('Yes');
+      await expect(
+        rows.nth(1).getByTestId('deposit-data-error-detected'),
+      ).toHaveText('No');
+      await expect(
+        rows.nth(2).getByTestId('deposit-data-error-detected'),
+      ).toHaveText('Yes');
+
+      await expect(rows.nth(0).getByTestId('deposit-data-error')).toContainText(
+        'amount is not equal to 32 ETH',
+      );
+      await expect(rows.nth(1).getByTestId('deposit-data-error')).toBeHidden();
+      await expect(rows.nth(2).getByTestId('deposit-data-error')).toContainText(
+        'amount is not equal to 32 ETH',
+      );
+    });
+  });
 });

--- a/tests/csm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/keys/parsed.spec.ts
@@ -30,7 +30,7 @@ test.describe('Operator with keys. Validation keys json.', async () => {
     await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
     for (const row of await keysPage.submitPage.depositDataRow.all()) {
       await expect(row.getByTestId('deposit-data-error')).toHaveText(
-        'amount is not equal to 32 ethinvalid signature',
+        'amount is not equal to 32 ETHsignature failed BLS verification',
       );
     }
   });
@@ -47,7 +47,7 @@ test.describe('Operator with keys. Validation keys json.', async () => {
     await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
     for (const row of await keysPage.submitPage.depositDataRow.all()) {
       await expect(row.getByTestId('deposit-data-error')).toHaveText(
-        'invalid signature',
+        'signature failed BLS verification',
       );
     }
   });
@@ -66,10 +66,10 @@ test.describe('Operator with keys. Validation keys json.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'invalid signature',
+          'signature failed BLS verification',
         );
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'pubkey is not valid string',
+          'pubkey is not a valid hex string',
         );
       }
     },
@@ -89,7 +89,7 @@ test.describe('Operator with keys. Validation keys json.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toHaveText(
-          'invalid signature',
+          'signature failed BLS verification',
         );
       }
     },
@@ -109,10 +109,10 @@ test.describe('Operator with keys. Validation keys json.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'invalid signature',
+          'signature failed BLS verification',
         );
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'deposit_message_root is not a valid string',
+          'deposit_message_root is not a valid hex string',
         );
       }
     },
@@ -133,7 +133,7 @@ test.describe('Operator with keys. Validation keys json.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toHaveText(
-          'withdrawal_credentials is not the Lido Withdrawal Vaultinvalid signature',
+          'withdrawal_credentials is not the Lido Withdrawal Vaultsignature failed BLS verification',
         );
       }
     },
@@ -154,10 +154,10 @@ test.describe('Operator with keys. Validation keys json.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'invalid signature',
+          'signature failed BLS verification',
         );
         await expect(row.getByTestId('deposit-data-error')).toContainText(
-          'withdrawal_credentials is not a valid string',
+          'withdrawal_credentials is not a valid hex string',
         );
       }
     },
@@ -199,7 +199,7 @@ test.describe('Operator with keys. Validation keys json.', async () => {
       await expect(keysPage.submitPage.depositDataRow).toHaveCount(1);
       for (const row of await keysPage.submitPage.depositDataRow.all()) {
         await expect(row.getByTestId('deposit-data-error')).toHaveText(
-          `network_name or eth2_network_name is not equal to ${widgetConfig.standConfig.networkConfig.chainName.toLowerCase()}`,
+          `network_name is not equal to ${widgetConfig.standConfig.networkConfig.chainName.toLowerCase()}`,
         );
       }
     },

--- a/tests/csm-widget/tests/operatorWithValidator/keys/validation.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/keys/validation.spec.ts
@@ -53,6 +53,20 @@ test.describe('Operator with keys. Validation keys json.', async () => {
     },
   );
 
+  test('Should disable Parsed tab for unparseable json', async () => {
+    await keysPage.submitPage.fillRawKeys('{ this is not valid json');
+
+    await test.step('Verify parse error is shown', async () => {
+      await expect(keysPage.submitPage.validationInputError).toBeVisible();
+    });
+
+    await test.step('Verify Parsed/Parameters tabs and parsed data are unavailable', async () => {
+      await expect(keysPage.submitPage.parsedTab).toBeDisabled();
+      await expect(keysPage.submitPage.parametersTab).toBeDisabled();
+      await expect(keysPage.submitPage.depositDataRow).toHaveCount(0);
+    });
+  });
+
   invalidTextValidation.forEach((propertyName) => {
     test(
       qase(

--- a/tests/csm-widget/tests/operatorWithValidator/keys/validation.spec.ts
+++ b/tests/csm-widget/tests/operatorWithValidator/keys/validation.spec.ts
@@ -86,8 +86,9 @@ test.describe('Operator with keys. Validation keys json.', async () => {
 
           await expect(keysPage.submitPage.amountInput).toBeDisabled();
           await expect(keysPage.submitPage.submitKeysButton).toBeDisabled();
-          // @TODO: Fix it after bug fixed
-          // await expect(keysPage.submitPage.confirmKeysReady).toBeDisabled();
+          await expect(
+            keysPage.submitPage.confirmKeysReadyInput,
+          ).toBeDisabled();
         });
       },
     );
@@ -126,8 +127,9 @@ test.describe('Operator with keys. Validation keys json.', async () => {
 
           await expect(keysPage.submitPage.amountInput).toBeDisabled();
           await expect(keysPage.submitPage.submitKeysButton).toBeDisabled();
-          // @TODO: Uncomment it after bug fixed
-          // await expect(keysPage.submitPage.confirmKeysReady).toBeDisabled();
+          await expect(
+            keysPage.submitPage.confirmKeysReadyInput,
+          ).toBeDisabled();
         });
       },
     );
@@ -164,8 +166,9 @@ test.describe('Operator with keys. Validation keys json.', async () => {
 
           await expect(keysPage.submitPage.amountInput).toBeDisabled();
           await expect(keysPage.submitPage.submitKeysButton).toBeDisabled();
-          // @TODO: Uncomment it after bug fixed
-          // await expect(keysPage.submitPage.confirmKeysReady).toBeDisabled();
+          await expect(
+            keysPage.submitPage.confirmKeysReadyInput,
+          ).toBeDisabled();
         });
       },
     );

--- a/utils/bond-curve.test.ts
+++ b/utils/bond-curve.test.ts
@@ -1,0 +1,86 @@
+import { bondForKeys, maxKeysForBond } from './bond-curve';
+
+// Curves use small integers; the functions are unit-agnostic integer math.
+// value = per-key trend, minKeyNumber is 1-based (interval i covers keys [m_i, m_{i+1}-1]).
+const LINEAR = [{ minKeyNumber: 1, value: 10n }];
+const TWO_TIER = [
+  { minKeyNumber: 1, value: 24n }, // keys 1-2 cost 24 each
+  { minKeyNumber: 3, value: 13n }, // keys 3+ cost 13 each
+];
+const THREE_TIER = [
+  { minKeyNumber: 1, value: 24n }, // keys 1-2
+  { minKeyNumber: 3, value: 13n }, // keys 3-5
+  { minKeyNumber: 6, value: 5n }, //  keys 6+
+];
+
+describe('bondForKeys', () => {
+  it('returns 0 for zero or negative counts', () => {
+    expect(bondForKeys(TWO_TIER, 0)).toBe(0n);
+    expect(bondForKeys(TWO_TIER, -1)).toBe(0n);
+  });
+
+  it('returns 0 for empty intervals', () => {
+    expect(bondForKeys([], 5)).toBe(0n);
+  });
+
+  it('sums a single linear interval', () => {
+    expect(bondForKeys(LINEAR, 1)).toBe(10n);
+    expect(bondForKeys(LINEAR, 5)).toBe(50n);
+  });
+
+  it('sums across interval boundaries using 1-based minKeyNumber', () => {
+    expect(bondForKeys(TWO_TIER, 1)).toBe(24n);
+    expect(bondForKeys(TWO_TIER, 2)).toBe(48n);
+    expect(bondForKeys(TWO_TIER, 3)).toBe(61n); // 48 + 13, NOT 72 (the old off-by-one)
+    expect(bondForKeys(TWO_TIER, 4)).toBe(74n);
+  });
+
+  it('handles three tiers', () => {
+    expect(bondForKeys(THREE_TIER, 5)).toBe(87n); // 2*24 + 3*13
+    expect(bondForKeys(THREE_TIER, 6)).toBe(92n); // + 5
+    expect(bondForKeys(THREE_TIER, 8)).toBe(102n); // + 2*5
+  });
+});
+
+describe('maxKeysForBond', () => {
+  it('returns 0 when amount cannot fund a single key', () => {
+    expect(maxKeysForBond(TWO_TIER, 0n)).toBe(0);
+    expect(maxKeysForBond(TWO_TIER, 23n)).toBe(0);
+  });
+
+  it('returns 0 for empty intervals', () => {
+    expect(maxKeysForBond([], 1000n)).toBe(0);
+  });
+
+  it('floors within a single linear interval', () => {
+    expect(maxKeysForBond(LINEAR, 50n)).toBe(5);
+    expect(maxKeysForBond(LINEAR, 55n)).toBe(5);
+    expect(maxKeysForBond(LINEAR, 9n)).toBe(0);
+  });
+
+  it('crosses interval boundaries and floors the remainder', () => {
+    expect(maxKeysForBond(TWO_TIER, 24n)).toBe(1);
+    expect(maxKeysForBond(TWO_TIER, 47n)).toBe(1);
+    expect(maxKeysForBond(TWO_TIER, 48n)).toBe(2);
+    expect(maxKeysForBond(TWO_TIER, 60n)).toBe(2);
+    expect(maxKeysForBond(TWO_TIER, 61n)).toBe(3);
+    expect(maxKeysForBond(TWO_TIER, 73n)).toBe(3);
+    expect(maxKeysForBond(TWO_TIER, 74n)).toBe(4);
+  });
+
+  it('handles three tiers', () => {
+    expect(maxKeysForBond(THREE_TIER, 87n)).toBe(5);
+    expect(maxKeysForBond(THREE_TIER, 91n)).toBe(5);
+    expect(maxKeysForBond(THREE_TIER, 92n)).toBe(6);
+  });
+});
+
+describe('round-trip', () => {
+  it('maxKeysForBond(bondForKeys(n)) === n', () => {
+    for (const curve of [LINEAR, TWO_TIER, THREE_TIER]) {
+      for (let n = 0; n <= 10; n++) {
+        expect(maxKeysForBond(curve, bondForKeys(curve, n))).toBe(n);
+      }
+    }
+  });
+});

--- a/utils/bond-curve.ts
+++ b/utils/bond-curve.ts
@@ -1,0 +1,60 @@
+/**
+ * Client-side reconstruction of the on-chain bond curve, computed from the
+ * `{ minKeyNumber, value }` intervals exposed by `CurveParameters.bondConfig`.
+ *
+ * Mirrors the contract semantics (and the SDK's `findKeyInterval`): intervals
+ * are 1-based and interval `i` covers keys `[minKeyNumber_i, minKeyNumber_{i+1} - 1]`,
+ * where `value` is the per-key bond (trend) within that interval. The last
+ * interval is unbounded.
+ *
+ * Intentionally SDK-free so it stays unit-testable (the SDK barrel pulls ESM
+ * that Jest cannot load); the structural `Interval` type matches `bondConfig`.
+ */
+type Interval = { minKeyNumber: number; value: bigint };
+
+/** Total bond required to fund `count` keys. */
+export const bondForKeys = (intervals: Interval[], count: number): bigint => {
+  if (count <= 0) return 0n;
+
+  let total = 0n;
+  for (let i = 0; i < intervals.length; i++) {
+    const start = intervals[i].minKeyNumber;
+    if (count < start) break;
+
+    const next = intervals[i + 1]?.minKeyNumber ?? Infinity;
+    const lastKey = Math.min(count, next - 1);
+    total += BigInt(lastKey - start + 1) * intervals[i].value;
+  }
+  return total;
+};
+
+/** Maximum number of keys `amount` can fund on the given curve (floored). */
+export const maxKeysForBond = (
+  intervals: Interval[],
+  amount: bigint,
+): number => {
+  if (amount <= 0n) return 0;
+
+  let spent = 0n;
+  let keys = 0;
+  for (let i = 0; i < intervals.length; i++) {
+    const { minKeyNumber: start, value: trend } = intervals[i];
+    const next = intervals[i + 1]?.minKeyNumber ?? Infinity;
+    const keysInInterval = next - start; // Infinity for the last interval
+
+    // Fully fund this interval and move on when we can afford all of it.
+    if (Number.isFinite(keysInInterval)) {
+      const fullCost = BigInt(keysInInterval) * trend;
+      if (spent + fullCost <= amount) {
+        spent += fullCost;
+        keys += keysInInterval;
+        continue;
+      }
+    }
+
+    // Otherwise buy as many keys as the remainder allows, then stop.
+    if (trend > 0n) keys += Number((amount - spent) / trend);
+    break;
+  }
+  return keys;
+};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './address-validation';
 export * from './bigint-utils';
+export * from './bond-curve';
 export * from './calculate-available-to-claim';
 export * from './compare-lowercase';
 export * from './compare-with-router-path';


### PR DESCRIPTION
### 📚 Stacked PR — merge bottom-up
- #542 — deps & tooling _(base ← `develop`)_
- #543 — tx-modal closable on Ledger
- #544 — claim-bond compensate copy
- 👉 **#545 — add-keys / deposit-data / add-bond**
- #546 — dvt apply-form
- #547 — misc UI (tooltip, rewards, change-role, delayed-penalty)

_Replaces the single large #539. Each PR targets the one below it; review/merge from #542 upward. Rebasing a lower PR cascades upward._

---

add-keys / deposit-data / add-bond fixes and copy alignment.
- add trailing dots to multi-sentence UI copy
- label add-bond info amount as "Excess bond" instead of "Bond balance"
- re-enable keys-available hint with client-side curve calc
- disable confirm checkbox when deposit data invalid
- disable spellcheck on key input fields
- fallback to placeholder for empty pubkey
- align deposit-data / add-bond test assertions with updated sdk/ui copy
- cover Parsed-tab availability and error counter
- respect curve keys limit on upload forms
