### PR TITLE
fix(dvt): apply-form validation fixes [stack 5/6]

### DIFF
--- a/features/dvt/apply-form/context/apply-form-provider.tsx
+++ b/features/dvt/apply-form/context/apply-form-provider.tsx
@@ -5,6 +5,7 @@ import {
   useFlowSubmit,
   useFormDefaultValues,
 } from 'shared/hook-form/form-controller';
+import { useDvtState } from 'features/dvt/shared';
 import { CLUSTER_SIZE } from './consts';
 import type { ClusterMember, DvtApplyFormInputType } from './types';
 import { useApplyFormData } from './apply-data-provider';
@@ -22,7 +23,11 @@ const createEmptyMembers = (): ClusterMember[] =>
 
 export const ApplyFormProvider: FC<PropsWithChildren> = ({ children }) => {
   const { mainAddress } = useApplyFormData(true);
-  const { stored, save, clear } = useFormPersist(mainAddress);
+  const { data } = useDvtState();
+  const submittedAt = data
+    ? new Date(data.updatedAt ?? data.createdAt).getTime()
+    : undefined;
+  const { draft, save, clear } = useFormPersist(mainAddress, submittedAt);
   const resolver = useApplyFormValidation();
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
@@ -34,7 +39,9 @@ export const ApplyFormProvider: FC<PropsWithChildren> = ({ children }) => {
       confirmed: false,
     };
 
-    if (!stored) return emptyDefaults;
+    if (!draft) return emptyDefaults;
+
+    const { savedAt: _savedAt, ...stored } = draft;
 
     return {
       ...emptyDefaults,

--- a/features/dvt/apply-form/context/use-form-persist.ts
+++ b/features/dvt/apply-form/context/use-form-persist.ts
@@ -1,14 +1,37 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { Address } from 'viem';
 import { useLocalStorage } from 'shared/hooks/use-local-storage';
 import { DvtApplyFormInputType } from './types';
 
-export const useFormPersist = (address: Address | undefined) => {
+type PersistedDraft = Partial<DvtApplyFormInputType> & { savedAt: number };
+
+export const useFormPersist = (
+  address: Address | undefined,
+  // last time the server-side application changed (createdAt/updatedAt)
+  submittedAt?: number,
+) => {
   const key = address ? `dvt-apply-${address.toLowerCase()}` : undefined;
-  const [stored, setStored] =
-    useLocalStorage<Partial<DvtApplyFormInputType> | null>(key, null);
+  const [stored, setStored] = useLocalStorage<PersistedDraft | null>(key, null);
+  const stoppedRef = useRef(false);
 
-  const clear = useCallback(() => setStored(null), [setStored]);
+  const clear = useCallback(() => {
+    // block any pending debounced write so the cleared state sticks
+    stoppedRef.current = true;
+    setStored(null);
+  }, [setStored]);
 
-  return { stored, save: setStored, clear } as const;
+  const save = useCallback(
+    (values: Partial<DvtApplyFormInputType>) => {
+      if (stoppedRef.current) return;
+      setStored({ ...values, savedAt: Date.now() });
+    },
+    [setStored],
+  );
+
+  // a draft is valid only if it was edited after the latest submission,
+  // so leftovers from a rejected attempt never resurface
+  const draft =
+    stored && (!submittedAt || stored.savedAt > submittedAt) ? stored : null;
+
+  return { draft, save, clear } as const;
 };

--- a/features/dvt/apply-form/controls/cluster-member-item.tsx
+++ b/features/dvt/apply-form/controls/cluster-member-item.tsx
@@ -42,7 +42,7 @@ export const ClusterMemberItem: FC<ClusterMemberItemProps> = ({ index }) => {
     name: `clusterMembers.${index}.verified` as const,
   });
 
-  const { getValues, setError, clearErrors, setValue } =
+  const { getValues, setError, clearErrors, setValue, trigger } =
     useFormContext<DvtApplyFormInputType>();
 
   const message = useClusterMemberMessage(watchedAddress);
@@ -76,6 +76,9 @@ export const ClusterMemberItem: FC<ClusterMemberItemProps> = ({ index }) => {
     setIsVerifying(true);
 
     try {
+      const isAddressValid = await trigger(`clusterMembers.${index}.address`);
+      if (!isAddressValid) return;
+
       const isValid = await verifyMessage({ address, signature });
 
       if (isValid) {
@@ -100,6 +103,7 @@ export const ClusterMemberItem: FC<ClusterMemberItemProps> = ({ index }) => {
     getValues,
     index,
     setError,
+    trigger,
     verifyMessage,
     isVerifying,
     verified,


### PR DESCRIPTION
### 📚 Stacked PR — merge bottom-up
- #542 — deps & tooling _(base ← `develop`)_
- #543 — tx-modal closable on Ledger
- #544 — claim-bond compensate copy
- #545 — add-keys / deposit-data / add-bond
- 👉 **#546 — dvt apply-form**
- #547 — misc UI (tooltip, rewards, change-role, delayed-penalty)

_Replaces the single large #539. Each PR targets the one below it; review/merge from #542 upward. Rebasing a lower PR cascades upward._

---

DVT apply-form fixes.
- check ICS approval before marking cluster member verified
- invalidate stale apply-form draft against server submission
