### PR TITLE
fix(matomo): distinct page events for settings and type sub-pages, fix spelling

### DIFF
--- a/consts/matomo-click-events.ts
+++ b/consts/matomo-click-events.ts
@@ -38,7 +38,7 @@ export const enum MATOMO_CLICK_EVENTS_TYPES {
   partnerEthdocker = 'partnerEthdocker',
   starterPackCSMLink = 'starterPackCSMLink',
   starterPackBondLink = 'starterPackBondLink',
-  starterPackHadwareLink = 'starterPackHadwareLink',
+  starterPackHardwareLink = 'starterPackHardwareLink',
   starterPackSetupValidatorLink = 'starterPackSetupValidatorLink',
   starterPackGenerateKeysLink = 'starterPackGenerateKeysLink',
   operatorTypeModalJoinPermissionless = 'operatorTypeModalJoinPermissionless',
@@ -50,7 +50,7 @@ export const enum MATOMO_CLICK_EVENTS_TYPES {
   depositDataLearnMore = 'depositDataLearnMore',
   howToClaimEth = 'howToClaimEth',
   customAddressDescription = 'customAddressDescription',
-  managerAdressPermissionTypeDescription = 'managerAdressPermissionTypeDescription',
+  managerAddressPermissionTypeDescription = 'managerAddressPermissionTypeDescription',
   createSuccessKeysTab = 'createSuccessKeysTab',
   createSuccessBeaconchainDashboard = 'createSuccessBeaconchainDashboard',
   createSuccessBeaconchain = 'createSuccessBeaconchain',
@@ -130,7 +130,7 @@ export const enum MATOMO_CLICK_EVENTS_TYPES {
   // Exit Keys
   exitKeysDappnodeLink = 'exitKeysDappnodeLink',
   exitKeysSedgeLink = 'exitKeysSedgeLink',
-  exitKeysSteureumLink = 'exitKeysSteureumLink',
+  exitKeysStereumLink = 'exitKeysStereumLink',
   exitKeysEthpillarLink = 'exitKeysEthpillarLink',
   exitKeysEthdockerLink = 'exitKeysEthdockerLink',
   exitKeysSystemdLink = 'exitKeysSystemdLink',
@@ -171,7 +171,7 @@ export const MATOMO_CLICK_EVENTS: Record<
     'connect_wallet',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.disconnectWallet]: createEvent(
-    'Push «Disonnect» button',
+    'Push «Disconnect» button',
     'disconnect_wallet',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.clickShowMoreWallets]: createEvent(
@@ -191,7 +191,7 @@ export const MATOMO_CLICK_EVENTS: Record<
     'connect_wallet_to_become_no',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.welcomeDetailedLink]: createEvent(
-    'Click on Deailed description about Module link',
+    'Click on Detailed description about Module link',
     'welcome_module_detailed_link',
   ),
   // Starter Pack
@@ -209,7 +209,7 @@ export const MATOMO_CLICK_EVENTS: Record<
   ),
   [MATOMO_CLICK_EVENTS_TYPES.partnerStereum]: createEvent(
     'Click partner «Stereum» link on StarterPack screen',
-    'starterpack_partner_stereu_link',
+    'starterpack_partner_stereum_link',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.partnerEthdocker]: createEvent(
     'Click partner «Eth Docker» link on StarterPack screen',
@@ -220,10 +220,10 @@ export const MATOMO_CLICK_EVENTS: Record<
     'starterpack_csm_link',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.starterPackBondLink]: createEvent(
-    'Click «Lear about Bond» link on StarterPack screen',
+    'Click «Learn about Bond» link on StarterPack screen',
     'starterpack_bond_link',
   ),
-  [MATOMO_CLICK_EVENTS_TYPES.starterPackHadwareLink]: createEvent(
+  [MATOMO_CLICK_EVENTS_TYPES.starterPackHardwareLink]: createEvent(
     'Click «Run hardware» link on StarterPack screen',
     'starterpack_hardware_link',
   ),
@@ -258,7 +258,7 @@ export const MATOMO_CLICK_EVENTS: Record<
   // Forms
   [MATOMO_CLICK_EVENTS_TYPES.depositDataLearnMore]: createEvent(
     'Click «Upload Deposit Data learn more» link on Upload form',
-    'deposti_data_learn_more_link',
+    'deposit_data_learn_more_link',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.howToClaimEth]: createEvent(
     'Click «Follow FAQ (ETH)» link on Claim form',
@@ -266,9 +266,9 @@ export const MATOMO_CLICK_EVENTS: Record<
   ),
   [MATOMO_CLICK_EVENTS_TYPES.customAddressDescription]: createEvent(
     'Click «Detailed description of custom addresses» link on Create NO form',
-    'cusstom_address_description_link',
+    'custom_address_description_link',
   ),
-  [MATOMO_CLICK_EVENTS_TYPES.managerAdressPermissionTypeDescription]:
+  [MATOMO_CLICK_EVENTS_TYPES.managerAddressPermissionTypeDescription]:
     createEvent(
       'Click «Detailed description of manager permission type» link on Create NO form',
       'manager_address_permission_type_link',
@@ -278,7 +278,7 @@ export const MATOMO_CLICK_EVENTS: Record<
     'create_success_keys_tab_link',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.createSuccessBeaconchainDashboard]: createEvent(
-    'Click «beaconcha.in bashboard» link after Create NO',
+    'Click «beaconcha.in dashboard» link after Create NO',
     'create_success_beaconchain_dashboard_link',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.createSuccessBeaconchain]: createEvent(
@@ -347,7 +347,7 @@ export const MATOMO_CLICK_EVENTS: Record<
   // Alerts
   [MATOMO_CLICK_EVENTS_TYPES.howToExitLinkRequestToExitAlert]: createEvent(
     'Click «How to exit» link on Request To Exit alert',
-    'how_to_exit_link_requset_to_exit_alert',
+    'how_to_exit_link_request_to_exit_alert',
   ),
   [MATOMO_CLICK_EVENTS_TYPES.normalizeQueueLinkAlert]: createEvent(
     'Click «Normalize queue» link on Normalize Queue alert',
@@ -557,7 +557,7 @@ export const MATOMO_CLICK_EVENTS: Record<
     'Click «Sedge» exit guide link',
     'exit_keys_sedge_link',
   ),
-  [MATOMO_CLICK_EVENTS_TYPES.exitKeysSteureumLink]: createEvent(
+  [MATOMO_CLICK_EVENTS_TYPES.exitKeysStereumLink]: createEvent(
     'Click «Stereum» exit guide link',
     'exit_keys_stereum_link',
   ),

--- a/features/change-role/claimer-page.tsx
+++ b/features/change-role/claimer-page.tsx
@@ -14,7 +14,7 @@ export const ClaimerPage: FC = () => {
     <Layout
       title="Settings"
       subtitle="Manage your operator"
-      pageName="Settings"
+      pageName="SettingsClaimer"
     >
       <SettingsPageSwitcher />
       <NoSSRWrapper key={key}>

--- a/features/change-role/manager-address-page.tsx
+++ b/features/change-role/manager-address-page.tsx
@@ -15,7 +15,7 @@ export const ManagerAddressPage: FC = () => {
     <Layout
       title="Settings"
       subtitle="Manage your operator"
-      pageName="Settings"
+      pageName="SettingsManagerAddress"
     >
       <SettingsPageSwitcher />
       <NoSSRWrapper key={key}>

--- a/features/change-role/reward-address-page.tsx
+++ b/features/change-role/reward-address-page.tsx
@@ -15,7 +15,7 @@ export const RewardAddressPage: FC = () => {
     <Layout
       title="Settings"
       subtitle="Manage your operator"
-      pageName="Settings"
+      pageName="SettingsRewardsAddress"
     >
       <SettingsPageSwitcher />
       <NoSSRWrapper key={key}>

--- a/features/change-role/roles-page.tsx
+++ b/features/change-role/roles-page.tsx
@@ -14,7 +14,7 @@ export const RolesPage: FC = () => {
     <Layout
       title="Settings"
       subtitle="Manage your operator"
-      pageName="Settings"
+      pageName="SettingsRoles"
     >
       <SettingsPageSwitcher />
       <NoSSRWrapper key={key}>

--- a/features/change-role/splits-page.tsx
+++ b/features/change-role/splits-page.tsx
@@ -14,7 +14,7 @@ export const SplitsPage: FC = () => {
     <Layout
       title="Settings"
       subtitle="Manage your operator"
-      pageName="Settings"
+      pageName="SettingsSplits"
     >
       <SettingsPageSwitcher />
       <NoSSRWrapper key={key}>

--- a/features/create-node-operator/submit-keys-form/controls/custom-addresses-section.tsx
+++ b/features/create-node-operator/submit-keys-form/controls/custom-addresses-section.tsx
@@ -41,7 +41,7 @@ export const CustomAddressesSection: FC = () => {
           $inline
           href={EXTENDED_MODE_LINK}
           matomoEvent={
-            MATOMO_CLICK_EVENTS_TYPES.managerAdressPermissionTypeDescription
+            MATOMO_CLICK_EVENTS_TYPES.managerAddressPermissionTypeDescription
           }
         >
           detailed explanation of the options

--- a/features/dvt/dvt-apply-page.tsx
+++ b/features/dvt/dvt-apply-page.tsx
@@ -10,7 +10,7 @@ export const DvtApplyPage: FC = () => (
   <Layout
     title="Apply for Identified DVT Cluster"
     subtitle="Get verified as an Independent DVT Cluster"
-    pageName="TypeDvt"
+    pageName="TypeDvtApply"
     mainPrefix={<TypeBackButton />}
   >
     <DvtPageSwitcher />

--- a/features/dvt/dvt-description-page.tsx
+++ b/features/dvt/dvt-description-page.tsx
@@ -17,7 +17,7 @@ export const DvtDescriptionPage: FC = () => (
   <Layout
     title="Apply for Identified DVT Cluster"
     subtitle="Get verified as an Independent DVT Cluster"
-    pageName="TypeDvt"
+    pageName="TypeDvtDescription"
     mainPrefix={<TypeBackButton />}
   >
     <DvtPageSwitcher />

--- a/features/exit-keys/exit-keys.tsx
+++ b/features/exit-keys/exit-keys.tsx
@@ -41,7 +41,7 @@ export const ExitKeys = () => {
             <MatomoLink
               icon="external"
               href="https://docs.lido.fi/run-on-lido/csm/lido-csm-widget/exiting-csm-validators/exit-using-validator-keystores#stereum"
-              matomoEvent={MATOMO_CLICK_EVENTS_TYPES.exitKeysSteureumLink}
+              matomoEvent={MATOMO_CLICK_EVENTS_TYPES.exitKeysStereumLink}
             >
               Guide for Stereum
             </MatomoLink>

--- a/features/ics/ics-apply-page.tsx
+++ b/features/ics/ics-apply-page.tsx
@@ -10,7 +10,7 @@ export const IcsApplyPage: FC = () => (
   <Layout
     title="Apply for Identified Community Stakers List"
     subtitle="Get verified as an Identified Community Staker"
-    pageName="TypeIcs"
+    pageName="TypeIcsApply"
     mainPrefix={<TypeBackButton />}
   >
     <IcsPageSwitcher />

--- a/features/ics/ics-scores-page.tsx
+++ b/features/ics/ics-scores-page.tsx
@@ -14,7 +14,7 @@ export const IcsScoresPage: FC = () => (
   <Layout
     title="Apply for Identified Community Stakers List"
     subtitle="Get verified as an Identified Community Staker"
-    pageName="TypeIcs"
+    pageName="TypeIcsSystem"
     mainPrefix={<TypeBackButton />}
   >
     <IcsPageSwitcher />

--- a/features/metadata/metadata-page.tsx
+++ b/features/metadata/metadata-page.tsx
@@ -12,7 +12,7 @@ export const MetadataPage: FC = () => {
     <Layout
       title="Settings"
       subtitle="Manage your operator"
-      pageName="Settings"
+      pageName="SettingsMetadata"
     >
       <SettingsPageSwitcher />
       <NoSSRWrapper key={key}>

--- a/features/starter-pack/stacter-pack-section/starter-pack-section.tsx
+++ b/features/starter-pack/stacter-pack-section/starter-pack-section.tsx
@@ -44,7 +44,7 @@ export const StarterPackSection: FC<PropsWithChildren> = ({ children }) => (
         <MatomoLink
           $inline
           href={PREPARE_HARDWARE_LINK}
-          matomoEvent={MATOMO_CLICK_EVENTS_TYPES.starterPackHadwareLink}
+          matomoEvent={MATOMO_CLICK_EVENTS_TYPES.starterPackHardwareLink}
         >
           your own hardware
         </MatomoLink>{' '}

--- a/features/type-parameters/type-parameters-page.tsx
+++ b/features/type-parameters/type-parameters-page.tsx
@@ -10,7 +10,7 @@ export const TypeParametersPage: FC = () => (
   <Layout
     title="Operator Type Parameters"
     subtitle="Compare parameters"
-    pageName="TypeParametersIcs"
+    pageName="TypeParameters"
     mainPrefix={<TypeBackButton />}
   >
     <TypePageSwitcher />


### PR DESCRIPTION
## What

Fixes duplicated and misspelled Matomo events.

### Page-view events — were firing one shared event across distinct routes
Each route renders `<Layout pageName=…>`, which fires `view_<pageName>_page`. Several distinct routes passed the **same** `pageName`, making them indistinguishable in Matomo:

- **Settings** — all 6 sub-pages fired `view_settings_page`. Split into distinct events: `SettingsRoles`, `SettingsRewardsAddress`, `SettingsManagerAddress`, `SettingsSplits`, `SettingsClaimer`, `SettingsMetadata`.
- **ICS tabs** — `ics-system` and `ics-apply` both fired `view_type_ics_page` → `TypeIcsSystem` / `TypeIcsApply`.
- **DVT tabs** — `idvtc-description` and `idvtc-apply` both fired `view_type_dvt_page` → `TypeDvtDescription` / `TypeDvtApply`.
- **Collision** — the general `/type/parameters` compare page was mislabeled `TypeParametersIcs` (colliding with the ICS-specific parameters page) → renamed to `TypeParameters`.

The two working, unique parameters events (`TypeParametersIcs`, `TypeParametersDvt`) are left untouched — they already form a coherent family, so renaming them would break live metrics for no benefit.

### Spelling
- Descriptions: `Disonnect`→Disconnect, `Deailed`→Detailed, `Lear`→Learn, `bashboard`→dashboard.
- Enum members: `Hadware`→Hardware, `Steureum`→Stereum, `Adress`→Address (+ call-sites).
- Keys: `stereu`→`stereum`, `cusstom`→`custom`.

## Notes
- Based on `develop`.
- Splitting/renaming keys starts fresh series in Matomo for the affected events.