### PR TITLE
feat: add flag to skip deposit data signature validation

### DIFF
--- a/config/feature-flags/types.ts
+++ b/config/feature-flags/types.ts
@@ -1,9 +1,12 @@
 export const ICS_APPLY_FORM = 'icsApplyForm';
 export const SURVEYS_SETUP_ENABLED = 'surveysSetupEnabled';
 export const DISABLE_DEPOSIT_DATA_VALIDATION = 'disableDepositDataValidation';
+export const DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION =
+  'disableDepositDataSignatureValidation';
 
 export type FeatureFlagsType = {
   [ICS_APPLY_FORM]: boolean;
   [SURVEYS_SETUP_ENABLED]: boolean;
   [DISABLE_DEPOSIT_DATA_VALIDATION]: boolean;
+  [DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION]: boolean;
 };

--- a/config/feature-flags/utils.ts
+++ b/config/feature-flags/utils.ts
@@ -5,6 +5,7 @@ import {
   ICS_APPLY_FORM,
   SURVEYS_SETUP_ENABLED,
   DISABLE_DEPOSIT_DATA_VALIDATION,
+  DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
 } from './types';
 
 const { defaultChain } = getConfig();
@@ -15,5 +16,6 @@ export const getFeatureFlagsDefault = (): FeatureFlagsType => {
     [ICS_APPLY_FORM]: isMainnet,
     [SURVEYS_SETUP_ENABLED]: isMainnet,
     [DISABLE_DEPOSIT_DATA_VALIDATION]: false,
+    [DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION]: false,
   };
 };

--- a/features/add-keys/add-keys/context/use-add-keys-validation.ts
+++ b/features/add-keys/add-keys/context/use-add-keys-validation.ts
@@ -1,5 +1,8 @@
 import { useFeatureFlags } from 'config/feature-flags';
-import { DISABLE_DEPOSIT_DATA_VALIDATION } from 'config/feature-flags/types';
+import {
+  DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
+  DISABLE_DEPOSIT_DATA_VALIDATION,
+} from 'config/feature-flags/types';
 import { useSmSDK } from 'modules/web3';
 import {
   useFormValidation,
@@ -62,6 +65,8 @@ export const useAddKeysValidation = () => {
             nonWithdrawnKeys:
               operatorInfo &&
               operatorInfo.totalAddedKeys - operatorInfo.totalWithdrawnKeys,
+            skipSignature:
+              featureFlags?.[DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION],
           });
         }
       });

--- a/features/create-node-operator/submit-keys-form/context/use-submit-keys-validation.ts
+++ b/features/create-node-operator/submit-keys-form/context/use-submit-keys-validation.ts
@@ -1,5 +1,8 @@
 import { useFeatureFlags } from 'config/feature-flags';
-import { DISABLE_DEPOSIT_DATA_VALIDATION } from 'config/feature-flags/types';
+import {
+  DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
+  DISABLE_DEPOSIT_DATA_VALIDATION,
+} from 'config/feature-flags/types';
 import { useSmSDK } from 'modules/web3';
 import {
   useFormValidation,
@@ -65,6 +68,8 @@ export const useSubmitKeysValidation = () => {
             depositData,
             sdk,
             keysLimit: curveParameters?.keysLimit,
+            skipSignature:
+              featureFlags?.[DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION],
           });
         }
       });

--- a/features/qa-config/qa-feature-flags.tsx
+++ b/features/qa-config/qa-feature-flags.tsx
@@ -4,6 +4,7 @@ import { CHAINS } from '@lidofinance/lido-ethereum-sdk';
 import { Checkbox, Text } from '@lidofinance/lido-ui';
 
 import {
+  DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
   DISABLE_DEPOSIT_DATA_VALIDATION,
   FeatureFlagsType,
   getFeatureFlagsDefault,
@@ -18,6 +19,8 @@ const FLAG_LABELS: Record<keyof FeatureFlagsType, string> = {
   [ICS_APPLY_FORM]: 'Operator type applications (ICS, IDVTC)',
   [SURVEYS_SETUP_ENABLED]: 'Surveys (setup & delegation)',
   [DISABLE_DEPOSIT_DATA_VALIDATION]: 'Disable deposit data validation',
+  [DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION]:
+    'Disable deposit data signature validation',
 };
 
 const FLAGS = Object.keys(getFeatureFlagsDefault()) as Array<

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@lidofinance/api-rpc": "^0.59.0",
     "@lidofinance/eth-api-providers": "^0.59.0",
     "@lidofinance/eth-providers": "^0.59.0",
-    "@lidofinance/lido-csm-sdk": "^2.0.0-alpha.70",
+    "@lidofinance/lido-csm-sdk": "^2.0.0-alpha.73",
     "@lidofinance/lido-ethereum-sdk": "^4.8.0",
     "@lidofinance/lido-ui": "^3.42.1",
     "@lidofinance/next-api-wrapper": "^0.59.0",

--- a/providers/modify-provider.tsx
+++ b/providers/modify-provider.tsx
@@ -4,6 +4,7 @@ import {
   ICS_APPLY_FORM,
   SURVEYS_SETUP_ENABLED,
   DISABLE_DEPOSIT_DATA_VALIDATION,
+  DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
 } from 'config/feature-flags/types';
 import { MATOMO_CLICK_EVENTS_TYPES } from 'consts/matomo-click-events';
 import { REF_MAPPING } from 'consts/ref-mapping';
@@ -30,6 +31,8 @@ const FEATURE_FLAG_QUERY_MAPPING: Record<string, keyof FeatureFlagsType> = {
   'ics-apply': ICS_APPLY_FORM,
   'survey-setup': SURVEYS_SETUP_ENABLED,
   'disable-deposit-validation': DISABLE_DEPOSIT_DATA_VALIDATION,
+  'disable-deposit-signature-validation':
+    DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
 };
 
 const ModifyContext = createContext<ModifyContextValue | null>(null);

--- a/shared/hook-form/validation/validate-deposit-data.ts
+++ b/shared/hook-form/validation/validate-deposit-data.ts
@@ -9,6 +9,7 @@ type ValidateDepositDataProps = {
   sdk: DepositDataSDK;
   keysLimit?: number;
   nonWithdrawnKeys?: number;
+  skipSignature?: boolean;
 };
 
 export const validateDepositData = async ({
@@ -16,11 +17,12 @@ export const validateDepositData = async ({
   sdk,
   keysLimit,
   nonWithdrawnKeys,
+  skipSignature,
 }: ValidateDepositDataProps) => {
   if (!depositData?.length) return;
 
   // 1. SDK validation of deposit data structure
-  const errors = await sdk.validateDepositData(depositData);
+  const errors = await sdk.validateDepositData(depositData, { skipSignature });
 
   if (errors?.length) {
     const types = mapValues(groupBy(errors, 'index'), (errors) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,10 +2424,10 @@
   resolved "https://registry.yarnpkg.com/@lidofinance/eth-providers/-/eth-providers-0.59.0.tgz#51c58c45519eff570fcd00b9c61f50f994bc325d"
   integrity sha512-asxrvPXhitjgt2xFk2RFyQIep7po5D/1bofqsK9wawfMqu2BTfTl5DPDHgiDzh9j2ZPujgIT27V1oO5CP00XBw==
 
-"@lidofinance/lido-csm-sdk@^2.0.0-alpha.70":
-  version "2.0.0-alpha.70"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-csm-sdk/-/lido-csm-sdk-2.0.0-alpha.70.tgz#f5950df805709d7de05345cc9ff9f875b13f43ad"
-  integrity sha512-xYqBld69QAOgUzpby8KJPse7rmFuIB0/Tew1ywYsrF8lJOvl8aIgnor42qdFwmcD9xab5IEtkGiX66XG9cG49Q==
+"@lidofinance/lido-csm-sdk@^2.0.0-alpha.73":
+  version "2.0.0-alpha.73"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-csm-sdk/-/lido-csm-sdk-2.0.0-alpha.73.tgz#c3a1e21fb49577bc8eb84483265175e1684fc2bb"
+  integrity sha512-4i2U2e/+klueUfpCxsGyVXfc14043B1d+YbpJCA02lgbLFayPmQXDRTzMttfMNxDkmNc/wPPuHpM5HxEfJZgjA==
   dependencies:
     "@chainsafe/ssz" "^1.3.0"
     "@openzeppelin/merkle-tree" "^1.0.8"


### PR DESCRIPTION
## What

Adds a dedicated **`DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION`** feature flag that skips **only** the BLS signature verification during deposit-data validation, while keeping all other checks (structure, withdrawal-credentials, duplicate / CL / uploaded-key detection, tx-limit and keys-limit).

It leverages the `skipSignature` option added to `validateDepositData` in `@lidofinance/lido-csm-sdk` **alpha-73**.

The existing `DISABLE_DEPOSIT_DATA_VALIDATION` flag is **unchanged** — it still skips the entire validation.

## How to enable

- QA config page toggle: *"Disable deposit data signature validation"*
- URL param: `?disable-deposit-signature-validation=1`

The two flags compose: `DISABLE_DEPOSIT_DATA_VALIDATION` is the outer gate (skip everything); when validation does run, the new flag narrows it to skip just the signature check.

## Changes

- `config/feature-flags/{types,utils}.ts` — new flag constant, type field, default `false`
- `providers/modify-provider.tsx` — URL-param mapping
- `features/qa-config/qa-feature-flags.tsx` — QA toggle label
- `shared/hook-form/validation/validate-deposit-data.ts` — new `skipSignature?` prop → `sdk.validateDepositData(depositData, { skipSignature })`
- `features/add-keys/.../use-add-keys-validation.ts` & `features/create-node-operator/.../use-submit-keys-validation.ts` — pass the new flag as `skipSignature`
- `package.json` + `yarn.lock` — `@lidofinance/lido-csm-sdk` `2.0.0-alpha.70` → `2.0.0-alpha.73`

## Testing

- `tsc --noEmit` — passes
- `yarn install --frozen-lockfile` — passes (lockfile consistent)
