### PR TITLE
feat: track IDVTC survey-API failures and sign-in denials in Matomo

### DIFF
--- a/features/add-keys/add-keys/context/use-add-keys-flow.ts
+++ b/features/add-keys/add-keys/context/use-add-keys-flow.ts
@@ -14,6 +14,8 @@ import { useCanPerform } from 'shared/hooks';
 import { useNavigate } from 'shared/navigate';
 import { handleTxError } from 'shared/transaction-modal';
 import invariant from 'tiny-invariant';
+import { classifyErrorCode, ErrorCode } from 'utils/get-error-code';
+import { trackMatomoRawError } from 'utils/track-matomo-event';
 import { useTxModalStagesAddKeys } from '../hooks/use-tx-modal-stages-add-keys';
 import { useAddKeysFormData } from './add-keys-data-provider';
 import { AddKeysFormInputType, AddKeysFormNetworkData } from './types';
@@ -53,6 +55,9 @@ export const useAddKeysFlowResolver = (): FlowResolver<
             await uploadStaged(op, dkgFiles);
             return true;
           } catch (error) {
+            if (classifyErrorCode(error) !== ErrorCode.DENIED_SIG) {
+              trackMatomoRawError('dkg_upload_add_keys', error);
+            }
             handleTxError(error);
             return false;
           }

--- a/features/claim-type/claim-idvtc-form/context/use-claim-idvtc-flow.tsx
+++ b/features/claim-type/claim-idvtc-form/context/use-claim-idvtc-flow.tsx
@@ -14,6 +14,11 @@ import {
 } from 'shared/hook-form/form-controller';
 import { TxStageSuccess, useTransitStage } from 'shared/transaction-modal';
 import invariant from 'tiny-invariant';
+import { classifyErrorCode, ErrorCode } from 'utils/get-error-code';
+import {
+  trackMatomoRawError,
+  trackMatomoSurveySigninDenied,
+} from 'utils/track-matomo-event';
 import { useConfirmClaimIdvtcModal } from '../hooks/use-confirm-modal';
 import { useTxModalStagesClaimIdvtc } from '../hooks/use-tx-modal-stages-claim-idvtc';
 import { useClaimIdvtcFormData } from './claim-idvtc-data-provider';
@@ -75,7 +80,10 @@ export const useClaimIdvtcFlowResolver = (): FlowResolver<
           if (canManage) {
             try {
               await surveyAuth.ensureAuth(<TxStageMembersSignin />);
-            } catch {
+            } catch (error) {
+              if (classifyErrorCode(error) === ErrorCode.DENIED_SIG) {
+                trackMatomoSurveySigninDenied('claim_idvtc');
+              }
               // Declined sign-in must not block claiming — skip auto-init
               return true;
             }
@@ -110,6 +118,7 @@ export const useClaimIdvtcFlowResolver = (): FlowResolver<
                   />,
                 );
               } catch (error) {
+                trackMatomoRawError('members_init', error);
                 console.warn('[members] in-flow init failed', error);
                 transitStage(
                   <TxStageMembersInitFailed

--- a/features/create-node-operator/submit-keys-form/context/use-submit-keys-flow.tsx
+++ b/features/create-node-operator/submit-keys-form/context/use-submit-keys-flow.tsx
@@ -24,6 +24,11 @@ import { useModuleOperatorTypeGetter } from 'shared/hooks';
 import { useNavigate } from 'shared/navigate';
 import { handleTxError, useTransitStage } from 'shared/transaction-modal';
 import invariant from 'tiny-invariant';
+import { classifyErrorCode, ErrorCode } from 'utils/get-error-code';
+import {
+  trackMatomoRawError,
+  trackMatomoSurveySigninDenied,
+} from 'utils/track-matomo-event';
 import { renderCreateSuccess } from '../hooks/create-success-stage';
 import { useConfirmCustomAddressesModal } from '../hooks/use-confirm-modal';
 import { useTxModalStagesSubmitKeys } from '../hooks/use-tx-modal-stages-submit-keys';
@@ -94,6 +99,9 @@ export const useSubmitKeysFlowResolver = (): FlowResolver<
                 await surveyAuth.ensureAuth(<TxStageMembersSignin />);
               }
             } catch (error) {
+              if (classifyErrorCode(error) === ErrorCode.DENIED_SIG) {
+                trackMatomoSurveySigninDenied('create_idvtc');
+              }
               // Staged DKG files must not be lost — abort. A declined sign-in
               // for auto-init alone must not block creating the operator.
               if (dkgFiles.length > 0) {
@@ -148,6 +156,7 @@ export const useSubmitKeysFlowResolver = (): FlowResolver<
                 await initStaged(op);
                 renderCreateSuccess(transitStage, result, data, keys);
               } catch (error) {
+                trackMatomoRawError('members_init', error);
                 console.warn('[members] in-flow init failed', error);
                 transitStage(
                   <TxStageMembersInitFailed
@@ -163,6 +172,7 @@ export const useSubmitKeysFlowResolver = (): FlowResolver<
               try {
                 await uploadStaged(op, dkgFiles);
               } catch (error) {
+                trackMatomoRawError('dkg_upload_create', error);
                 transitStage(
                   <TxStageDkgUploadFailed
                     nodeOperatorId={result.nodeOperatorId}

--- a/features/idvtc/dkg/hooks/use-upload-dkg-files.ts
+++ b/features/idvtc/dkg/hooks/use-upload-dkg-files.ts
@@ -4,6 +4,7 @@ import type {
   FileUploadItemDto,
 } from 'modules/surveys-sdk/generated';
 import invariant from 'tiny-invariant';
+import { trackMatomoRawError } from 'utils/track-matomo-event';
 import { dkgFilesKey } from './dkg-keys';
 import { uploadDkgFilesRequest } from './upload-dkg-files-request';
 
@@ -14,6 +15,9 @@ export const useUploadDkgFiles = () => {
       invariant(op);
       return uploadDkgFilesRequest(op, body, token);
     },
-    { invalidate: [dkgFilesKey(op)] },
+    {
+      invalidate: [dkgFilesKey(op)],
+      onError: (err) => trackMatomoRawError('dkg_upload_page', err),
+    },
   );
 };

--- a/features/idvtc/dkg/tx-stages/tx-stage-dkg-upload-failed.tsx
+++ b/features/idvtc/dkg/tx-stages/tx-stage-dkg-upload-failed.tsx
@@ -4,6 +4,7 @@ import { PATH } from 'consts/urls';
 import { LocalLink } from 'shared/navigate';
 import { TransactionModalContent } from 'shared/transaction-modal/transaction-modal-content';
 import { StageIconLimit } from 'shared/transaction-modal/tx-stages-basic/icons';
+import { Stack } from 'shared/components';
 
 type Props = {
   nodeOperatorId: bigint;
@@ -24,12 +25,17 @@ export const TxStageDkgUploadFailed: FC<Props> = ({
       </>
     }
     footer={
-      <>
-        <Button fullwidth onClick={onRetry}>
+      <Stack direction="column" gap="sm">
+        <Button fullwidth onClick={onRetry} size="sm">
           Retry upload
         </Button>
-        <LocalLink href={PATH.IDVTC_DKG}>Manage DKG files</LocalLink>
-      </>
+
+        <LocalLink href={PATH.IDVTC_DKG}>
+          <Button fullwidth size="sm" variant="translucent">
+            Manage DKG files
+          </Button>
+        </LocalLink>
+      </Stack>
     }
   />
 );

--- a/utils/track-matomo-event.ts
+++ b/utils/track-matomo-event.ts
@@ -5,6 +5,7 @@ import {
   createEvent,
 } from 'consts/matomo-click-events';
 import { snakeCase } from 'lodash';
+import { extractErrorMessage } from './extract-error-message';
 
 export type WithMatomoEvent<P = unknown> = P & {
   matomoEvent?: MATOMO_CLICK_EVENTS_TYPES | undefined;
@@ -21,6 +22,21 @@ export const trackMatomoFaqEvent = (faqId?: string) => {
 
 export const trackMatomoError = (description: string, tag: string) => {
   trackEvent(...createEvent(`ERROR: ${description}`, `error_${tag}`));
+};
+
+export const trackMatomoRawError = (tag: string, error: unknown) => {
+  trackMatomoError(`${extractErrorMessage(error)}`, tag);
+};
+
+export const trackMatomoSurveySigninDenied = (
+  flow: 'create_idvtc' | 'claim_idvtc',
+) => {
+  trackEvent(
+    ...createEvent(
+      `Declined surveys sign-in during ${flow}`,
+      `surveys_signin_denied_${flow}`,
+    ),
+  );
 };
 
 export const trackMatomoFormEvent = (


### PR DESCRIPTION
## What

Adds Matomo tracking to IDVTC survey-API failure paths that render custom `TxStage*Failed` components and therefore bypassed the existing `getErrorCode → trackMatomoError` tracking. Also tracks when a user declines the surveys (SIWE) sign-in during create-IDVTC / claim-IDVTC.

Stacked on #561 