### PR TITLE
feat: cap DKG file and batch upload size

### DIFF
--- a/consts/survey-api-copy.ts
+++ b/consts/survey-api-copy.ts
@@ -30,6 +30,13 @@ export const SURVEY_API_COPY: Record<string, string> = {
   FILES_QUOTA_EXCEEDED:
     'You have reached your 100 MB storage limit for DKG files',
   FILES_COUNT_EXCEEDED: 'You have reached the maximum number of DKG files',
+  // NOT part of the backend's catalog — synthesized client-side in
+  // upload-dkg-files-request.ts. The server's real 413 for an oversized batch
+  // carries no Access-Control-Allow-Origin header, so the browser blocks it
+  // and the client never sees an HTTP status to key off; we detect the
+  // opaque transport failure ourselves and fabricate this code/copy.
+  FILES_PAYLOAD_TOO_LARGE:
+    'This batch is too large to upload. Try uploading fewer files at once.',
 
   // Members
   MEMBERS_NO_BINDABLE_FORM:

--- a/consts/survey-api-copy.ts
+++ b/consts/survey-api-copy.ts
@@ -27,6 +27,9 @@ export const SURVEY_API_COPY: Record<string, string> = {
   // Files
   FILES_EMPTY_PAYLOAD: 'No file was uploaded',
   FILES_NOT_FOUND: 'The requested file does not exist',
+  FILES_QUOTA_EXCEEDED:
+    'You have reached your 100 MB storage limit for DKG files',
+  FILES_COUNT_EXCEEDED: 'You have reached the maximum number of DKG files',
 
   // Members
   MEMBERS_NO_BINDABLE_FORM:

--- a/consts/survey-api-copy.ts
+++ b/consts/survey-api-copy.ts
@@ -31,10 +31,7 @@ export const SURVEY_API_COPY: Record<string, string> = {
     'You have reached your 100 MB storage limit for DKG files',
   FILES_COUNT_EXCEEDED: 'You have reached the maximum number of DKG files',
   // NOT part of the backend's catalog — synthesized client-side in
-  // upload-dkg-files-request.ts. The server's real 413 for an oversized batch
-  // carries no Access-Control-Allow-Origin header, so the browser blocks it
-  // and the client never sees an HTTP status to key off; we detect the
-  // opaque transport failure ourselves and fabricate this code/copy.
+  // upload-dkg-files-request.ts.
   FILES_PAYLOAD_TOO_LARGE:
     'This batch is too large to upload. Try uploading fewer files at once.',
 

--- a/features/add-keys/add-keys/context/use-add-keys-validation.ts
+++ b/features/add-keys/add-keys/context/use-add-keys-validation.ts
@@ -3,6 +3,7 @@ import {
   DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
   DISABLE_DEPOSIT_DATA_VALIDATION,
 } from 'config/feature-flags/types';
+import { validateDkgBatch } from 'features/idvtc/dkg/utils/validate-dkg-batch';
 import { useSmSDK } from 'modules/web3';
 import {
   useFormValidation,
@@ -20,7 +21,14 @@ export const useAddKeysValidation = () => {
   return useFormValidation<AddKeysFormInputType, AddKeysFormNetworkData>(
     'token',
     async (
-      { token, bondAmount, depositData, rawDepositData, confirmKeysReady },
+      {
+        token,
+        bondAmount,
+        depositData,
+        rawDepositData,
+        dkgFiles,
+        confirmKeysReady,
+      },
       {
         operatorInfo,
         curveParameters,
@@ -70,6 +78,11 @@ export const useAddKeysValidation = () => {
               featureFlags?.[DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION],
           });
         }
+      });
+
+      await validate('dkgFiles', () => {
+        const error = validateDkgBatch(dkgFiles ?? []);
+        if (error) throw new ValidationError('dkgFiles', error);
       });
 
       await validate('confirmKeysReady', () => {

--- a/features/create-node-operator/submit-keys-form/context/use-submit-keys-validation.ts
+++ b/features/create-node-operator/submit-keys-form/context/use-submit-keys-validation.ts
@@ -3,6 +3,7 @@ import {
   DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
   DISABLE_DEPOSIT_DATA_VALIDATION,
 } from 'config/feature-flags/types';
+import { validateDkgBatch } from 'features/idvtc/dkg/utils/validate-dkg-batch';
 import { useSmSDK } from 'modules/web3';
 import {
   useFormValidation,
@@ -29,6 +30,7 @@ export const useSubmitKeysValidation = () => {
         bondAmount,
         depositData,
         rawDepositData,
+        dkgFiles,
         specifyCustomAddresses,
         rewardsAddress,
         managerAddress,
@@ -73,6 +75,11 @@ export const useSubmitKeysValidation = () => {
               featureFlags?.[DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION],
           });
         }
+      });
+
+      await validate('dkgFiles', () => {
+        const error = validateDkgBatch(dkgFiles ?? []);
+        if (error) throw new ValidationError('dkgFiles', error);
       });
 
       await validate('confirmKeysReady', () => {

--- a/features/idvtc/dkg/components/dkg-files-field.tsx
+++ b/features/idvtc/dkg/components/dkg-files-field.tsx
@@ -5,6 +5,12 @@ import { useController, useFormContext } from 'react-hook-form';
 import { FormTitle, Stack } from 'shared/components';
 import { useDkgUploadZone } from '../hooks/use-dkg-upload-zone';
 import { mergeDkgFiles } from '../utils/merge-dkg-files';
+import {
+  dkgBatchBytes,
+  formatMegabytes,
+  formatMegabytesFloor,
+  MAX_TOTAL_BYTES,
+} from '../utils/validate-dkg-batch';
 import { DkgAddFileButton } from './dkg-add-file-button';
 import { DkgDropArea } from './dkg-drop-area';
 import { DkgStagedTable } from './dkg-files-table';
@@ -13,7 +19,9 @@ import { AddButtonRow } from '../styles';
 
 export const DkgFilesField: FC<{ name?: string }> = ({ name = 'dkgFiles' }) => {
   const { control } = useFormContext();
-  const { field } = useController<Record<string, FileUploadItemDto[]>>({
+  const { field, fieldState } = useController<
+    Record<string, FileUploadItemDto[]>
+  >({
     name,
     control,
   });
@@ -22,6 +30,9 @@ export const DkgFilesField: FC<{ name?: string }> = ({ name = 'dkgFiles' }) => {
   const zone = useDkgUploadZone({
     onAccepted: (items) => field.onChange(mergeDkgFiles(staged, items)),
   });
+
+  const bytes = dkgBatchBytes(staged);
+  const isOverCap = bytes > MAX_TOTAL_BYTES;
 
   return (
     <>
@@ -38,6 +49,17 @@ export const DkgFilesField: FC<{ name?: string }> = ({ name = 'dkgFiles' }) => {
               field.onChange(staged.filter((_, idx) => idx !== index))
             }
           />
+          {staged.length > 0 && (
+            <Text size="xxs" color={isOverCap ? 'error' : 'secondary'}>
+              Total {formatMegabytes(bytes)} /{' '}
+              {formatMegabytesFloor(MAX_TOTAL_BYTES)}
+            </Text>
+          )}
+          {fieldState.error?.message && (
+            <Text size="xxs" color="error">
+              {fieldState.error.message}
+            </Text>
+          )}
           <AddButtonRow>
             <DkgAddFileButton onClick={zone.open} />
           </AddButtonRow>

--- a/features/idvtc/dkg/dkg-files-page.tsx
+++ b/features/idvtc/dkg/dkg-files-page.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@lidofinance/lido-ui';
-import { FC, useCallback } from 'react';
+import { FC, useCallback, useState } from 'react';
 import {
   Block,
   Counter,
@@ -20,6 +20,7 @@ import { useDkgUploadZone } from './hooks/use-dkg-upload-zone';
 import { useUploadDkgFiles } from './hooks/use-upload-dkg-files';
 import { DropArea } from './styles';
 import type { DkgFileUploadItem } from './types';
+import { validateDkgBatch } from './utils/validate-dkg-batch';
 
 const DkgFilesContent: FC = () => {
   const check = useShowRule();
@@ -27,9 +28,18 @@ const DkgFilesContent: FC = () => {
   const canManage = check('HAS_MANAGER_ROLE') || check('HAS_REWARDS_ROLE');
   const { data: files, isLoading } = useDkgFiles();
   const upload = useUploadDkgFiles();
+  const [batchError, setBatchError] = useState<string>();
 
   const onAccepted = useCallback(
-    (items: DkgFileUploadItem[]) => upload.mutate(items),
+    (items: DkgFileUploadItem[]) => {
+      const error = validateDkgBatch(items);
+      if (error) {
+        setBatchError(error);
+        return;
+      }
+      setBatchError(undefined);
+      upload.mutate(items);
+    },
     [upload],
   );
 
@@ -74,6 +84,11 @@ const DkgFilesContent: FC = () => {
         rejected={zone.rejected}
         onDismiss={zone.dismissRejected}
       />
+      {batchError && (
+        <Text size="xs" color="error">
+          {batchError}
+        </Text>
+      )}
       {upload.error && (
         <Text size="xs" color="error">
           Upload failed: {upload.error.message}

--- a/features/idvtc/dkg/hooks/upload-dkg-files-request.ts
+++ b/features/idvtc/dkg/hooks/upload-dkg-files-request.ts
@@ -10,26 +10,14 @@ import {
   type FileUploadItemDto,
 } from 'modules/surveys-sdk/generated';
 
-// The csm-survey-api's Fastify `BODY_LIMIT` — the hard ceiling on the ENTIRE
-// request body (this endpoint POSTs the whole batch as one JSON array), not
-// the 4 MB per-file cap enforced client-side in validate-dkg-file.ts. A batch
-// over this line gets a real 413 from the server, but that 413 carries no
-// Access-Control-Allow-Origin header, so the browser blocks it and `fetch`
-// rejects before any HTTP status ever reaches us (see the opaque-transport-
-// failure detection below).
-const SERVER_BODY_LIMIT_BYTES = 6 * 1024 * 1024;
+// The server's 413 for an over-limit body carries no CORS header, so the
+// browser blocks it and `fetch` only sees an opaque transport failure.
+const SERVER_BODY_LIMIT_BYTES = 4_300_000;
 
-// Operator-facing copy for the synthesized FILES_PAYLOAD_TOO_LARGE code below
-// (see the matching entry + comment in consts/survey-api-copy.ts). Deliberately
-// silent about the 6 MiB number and the transport mechanics — operators just
-// need to know to split the batch.
+// Deliberately vague about the byte limit — operators just need to split the batch.
 const PAYLOAD_TOO_LARGE_MESSAGE =
   'This batch is too large to upload. Try uploading fewer files at once.';
 
-// Single source of truth for the DKG files POST, shared by the standalone page
-// mutation (useUploadDkgFiles) and the in-flow upload (useDkgInFlowUpload) so
-// the endpoint shape and path stay in one place. The token is passed in — never
-// read from a closure — so a first-time sign-in threads the fresh token here.
 export const uploadDkgFilesRequest = async (
   op: OperatorKey,
   files: FileUploadItemDto[],
@@ -44,13 +32,8 @@ export const uploadDkgFilesRequest = async (
       }),
     );
   } catch (error) {
-    // `status === 0` is the signal survey-client's error interceptor uses for
-    // an opaque transport failure — no Response ever reached us (network
-    // outage, or exactly the CORS-blocked 413 described above). Only reclassify
-    // it as "payload too large" when the batch actually crosses the server's
-    // ceiling; below that line an opaque failure is a genuine network problem
-    // and must keep its own error. Computed lazily here (not up front) so the
-    // success path never pays for a second multi-MB JSON.stringify.
+    // status === 0 means no Response reached us — reclassify as "payload too
+    // large" only if the batch actually crosses the server's ceiling.
     if (error instanceof SurveysApiError && error.status === 0) {
       const bodyBytes = new TextEncoder().encode(
         JSON.stringify(files),

--- a/features/idvtc/dkg/hooks/upload-dkg-files-request.ts
+++ b/features/idvtc/dkg/hooks/upload-dkg-files-request.ts
@@ -1,6 +1,7 @@
 import {
   callSurvey,
   surveyRequest,
+  SurveysApiError,
   type OperatorKey,
 } from 'modules/surveys-sdk';
 import {
@@ -9,19 +10,64 @@ import {
   type FileUploadItemDto,
 } from 'modules/surveys-sdk/generated';
 
+// The csm-survey-api's Fastify `BODY_LIMIT` — the hard ceiling on the ENTIRE
+// request body (this endpoint POSTs the whole batch as one JSON array), not
+// the 4 MB per-file cap enforced client-side in validate-dkg-file.ts. A batch
+// over this line gets a real 413 from the server, but that 413 carries no
+// Access-Control-Allow-Origin header, so the browser blocks it and `fetch`
+// rejects before any HTTP status ever reaches us (see the opaque-transport-
+// failure detection below).
+const SERVER_BODY_LIMIT_BYTES = 6 * 1024 * 1024;
+
+// Operator-facing copy for the synthesized FILES_PAYLOAD_TOO_LARGE code below
+// (see the matching entry + comment in consts/survey-api-copy.ts). Deliberately
+// silent about the 6 MiB number and the transport mechanics — operators just
+// need to know to split the batch.
+const PAYLOAD_TOO_LARGE_MESSAGE =
+  'This batch is too large to upload. Try uploading fewer files at once.';
+
 // Single source of truth for the DKG files POST, shared by the standalone page
 // mutation (useUploadDkgFiles) and the in-flow upload (useDkgInFlowUpload) so
 // the endpoint shape and path stay in one place. The token is passed in — never
 // read from a closure — so a first-time sign-in threads the fresh token here.
-export const uploadDkgFilesRequest = (
+export const uploadDkgFilesRequest = async (
   op: OperatorKey,
   files: FileUploadItemDto[],
   token: string | undefined,
-): Promise<FileMetadataDto[] | undefined> =>
-  callSurvey(() =>
-    filesUpload({
-      ...surveyRequest(token),
-      path: { nodeOperatorId: op },
-      body: files,
-    }),
-  );
+): Promise<FileMetadataDto[] | undefined> => {
+  try {
+    return await callSurvey(() =>
+      filesUpload({
+        ...surveyRequest(token),
+        path: { nodeOperatorId: op },
+        body: files,
+      }),
+    );
+  } catch (error) {
+    // `status === 0` is the signal survey-client's error interceptor uses for
+    // an opaque transport failure — no Response ever reached us (network
+    // outage, or exactly the CORS-blocked 413 described above). Only reclassify
+    // it as "payload too large" when the batch actually crosses the server's
+    // ceiling; below that line an opaque failure is a genuine network problem
+    // and must keep its own error. Computed lazily here (not up front) so the
+    // success path never pays for a second multi-MB JSON.stringify.
+    if (error instanceof SurveysApiError && error.status === 0) {
+      const bodyBytes = new TextEncoder().encode(
+        JSON.stringify(files),
+      ).byteLength;
+      if (bodyBytes > SERVER_BODY_LIMIT_BYTES) {
+        throw new SurveysApiError({
+          message: PAYLOAD_TOO_LARGE_MESSAGE,
+          status: 413,
+          url: error.url || '',
+          body: {
+            code: 'FILES_PAYLOAD_TOO_LARGE',
+            message: PAYLOAD_TOO_LARGE_MESSAGE,
+          },
+          cause: error,
+        });
+      }
+    }
+    throw error;
+  }
+};

--- a/features/idvtc/dkg/hooks/use-dkg-in-flow-upload.tsx
+++ b/features/idvtc/dkg/hooks/use-dkg-in-flow-upload.tsx
@@ -37,7 +37,16 @@ export const useDkgInFlowUpload = ({
     async (op: OperatorKey, files: FileUploadItemDto[]): Promise<void> => {
       if (files.length === 0) return;
       transitStage(<TxStageDkgUploading count={files.length} />);
-      await uploadDkgFilesRequest(op, files, getToken());
+      // We just set a non-terminal pending stage above, so this hook owns
+      // the terminal failure state too — a caller's catch may only run
+      // `handleTxError`, a predicate that transits nothing, leaving the
+      // modal stuck on the spinner forever.
+      try {
+        await uploadDkgFilesRequest(op, files, getToken());
+      } catch (error) {
+        getGeneralTransactionModalStages(transitStage).failed(error);
+        throw error;
+      }
       await queryClient.invalidateQueries({ queryKey: dkgFilesKey(op) });
     },
     [transitStage, queryClient, getToken],

--- a/features/idvtc/dkg/utils/validate-dkg-batch.test.ts
+++ b/features/idvtc/dkg/utils/validate-dkg-batch.test.ts
@@ -1,0 +1,82 @@
+import type { FileUploadItemDto } from 'modules/surveys-sdk/generated';
+import { validationMessage } from 'shared/hook-form/validation/messages';
+import {
+  dkgBatchBytes,
+  formatMegabytes,
+  formatMegabytesFloor,
+  MAX_TOTAL_BYTES,
+  validateDkgBatch,
+} from './validate-dkg-batch';
+
+const fileOfBytes = (
+  name: string,
+  contentByteLength: number,
+): FileUploadItemDto => ({
+  name,
+  content: { blob: 'y'.repeat(Math.max(0, contentByteLength)) },
+});
+
+const tooLargeMessage = validationMessage.dkgBatchTooLarge(
+  formatMegabytesFloor(MAX_TOTAL_BYTES),
+);
+
+describe('validateDkgBatch', () => {
+  it('passes for an empty list', () => {
+    expect(dkgBatchBytes([])).toBe(2); // "[]"
+    expect(validateDkgBatch([])).toBeUndefined();
+  });
+
+  it('passes for a batch comfortably under the cap', () => {
+    const files = [fileOfBytes('a.json', 100), fileOfBytes('b.json', 100)];
+    expect(dkgBatchBytes(files)).toBeLessThan(MAX_TOTAL_BYTES);
+    expect(validateDkgBatch(files)).toBeUndefined();
+  });
+
+  it('returns the error copy for a batch over the cap', () => {
+    const files = [fileOfBytes('a.json', MAX_TOTAL_BYTES)];
+    expect(dkgBatchBytes(files)).toBeGreaterThan(MAX_TOTAL_BYTES);
+    expect(validateDkgBatch(files)).toBe(tooLargeMessage);
+  });
+
+  it('passes exactly at MAX_TOTAL_BYTES and fails one byte over', () => {
+    // Binary-search the padding so JSON.stringify([...]) lands exactly at the cap.
+    const build = (padding: number): FileUploadItemDto[] => [
+      { name: 'a.json', content: { blob: 'y'.repeat(Math.max(0, padding)) } },
+    ];
+
+    let lo = 0;
+    let hi = MAX_TOTAL_BYTES;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (dkgBatchBytes(build(mid)) <= MAX_TOTAL_BYTES) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+
+    const atCap = build(lo);
+    expect(dkgBatchBytes(atCap)).toBeLessThanOrEqual(MAX_TOTAL_BYTES);
+    expect(dkgBatchBytes(build(lo + 1))).toBe(MAX_TOTAL_BYTES + 1);
+    expect(validateDkgBatch(atCap)).toBeUndefined();
+    expect(validateDkgBatch(build(lo + 1))).toBe(tooLargeMessage);
+  });
+
+  it('counts long file names toward the total', () => {
+    const shortName = [{ name: 'a.json', content: {} }];
+    const longName = [{ name: 'a'.repeat(10_000) + '.json', content: {} }];
+    expect(dkgBatchBytes(longName)).toBeGreaterThan(
+      dkgBatchBytes(shortName) + 9_000,
+    );
+  });
+
+  it('formatMegabytes rounds up', () => {
+    expect(formatMegabytes(MAX_TOTAL_BYTES)).toBe('4.2 MB');
+    expect(formatMegabytes(4.15 * 1024 * 1024)).not.toBe('4.1 MB');
+  });
+
+  it('formatMegabytesFloor rounds down', () => {
+    expect(formatMegabytesFloor(MAX_TOTAL_BYTES)).toBe('4.1 MB');
+    expect(formatMegabytesFloor(4.19 * 1024 * 1024)).toBe('4.1 MB');
+  });
+});

--- a/features/idvtc/dkg/utils/validate-dkg-batch.ts
+++ b/features/idvtc/dkg/utils/validate-dkg-batch.ts
@@ -1,0 +1,26 @@
+import type { FileUploadItemDto } from 'modules/surveys-sdk/generated';
+import { validationMessage } from 'shared/hook-form/validation/messages';
+import { byteLength } from './validate-dkg-file';
+
+// Matches the server's Fastify BODY_LIMIT (csm-survey-api/src/app/bootstrap/constants.ts).
+export const MAX_TOTAL_BYTES = 4_300_000;
+
+export const dkgBatchBytes = (files: FileUploadItemDto[]): number =>
+  byteLength(JSON.stringify(files));
+
+export const validateDkgBatch = (
+  files: FileUploadItemDto[],
+): string | undefined => {
+  if (dkgBatchBytes(files) > MAX_TOTAL_BYTES) {
+    return validationMessage.dkgBatchTooLarge(
+      formatMegabytesFloor(MAX_TOTAL_BYTES),
+    );
+  }
+  return undefined;
+};
+
+export const formatMegabytes = (bytes: number): string =>
+  `${(Math.ceil((bytes / (1024 * 1024)) * 10) / 10).toFixed(1)} MB`;
+
+export const formatMegabytesFloor = (bytes: number): string =>
+  `${(Math.floor((bytes / (1024 * 1024)) * 10) / 10).toFixed(1)} MB`;

--- a/features/idvtc/dkg/utils/validate-dkg-file.test.ts
+++ b/features/idvtc/dkg/utils/validate-dkg-file.test.ts
@@ -45,7 +45,7 @@ describe('validateDkgFile', () => {
     expect(r.ok).toBe(false);
     expect(r).toMatchObject({
       ok: false,
-      reason: expect.stringMatching(/64|large|size/i),
+      reason: expect.stringMatching(/large|size/i),
     });
   });
 

--- a/features/idvtc/dkg/utils/validate-dkg-file.ts
+++ b/features/idvtc/dkg/utils/validate-dkg-file.ts
@@ -1,9 +1,7 @@
 import type { DkgFileUploadItem } from '../types';
 
 export const MAX_NAME_LENGTH = 255;
-// 4 MB after JSON.stringify — deliberately stricter than the API's own 5 MiB
-// per-file cap, so an oversized file is rejected client-side before the
-// server ever sees it.
+// Mirrors the API's own per-file cap (MAX_CONTENT_BYTES in is-valid-json-content.validator.ts).
 export const MAX_CONTENT_BYTES = 4 * 1024 * 1024;
 
 export type ValidateResult =
@@ -11,7 +9,7 @@ export type ValidateResult =
 
 const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
 
-const byteLength = (s: string): number =>
+export const byteLength = (s: string): number =>
   encoder ? encoder.encode(s).byteLength : Buffer.byteLength(s, 'utf8');
 
 // TODO: fix types of content

--- a/features/idvtc/dkg/utils/validate-dkg-file.ts
+++ b/features/idvtc/dkg/utils/validate-dkg-file.ts
@@ -1,7 +1,7 @@
 import type { DkgFileUploadItem } from '../types';
 
 export const MAX_NAME_LENGTH = 255;
-export const MAX_CONTENT_BYTES = 64 * 1024; // 64 KB after JSON.stringify
+export const MAX_CONTENT_BYTES = 5 * 1024 * 1024; // 5 MiB after JSON.stringify
 
 export type ValidateResult =
   { ok: true; item: DkgFileUploadItem } | { ok: false; reason: string };
@@ -35,7 +35,7 @@ export const validateDkgFile = (name: string, text: string): ValidateResult => {
   }
 
   if (byteLength(JSON.stringify(content)) > MAX_CONTENT_BYTES) {
-    return { ok: false, reason: 'File is larger than 64 KB' };
+    return { ok: false, reason: 'File is larger than 5 MB' };
   }
 
   return { ok: true, item: { name, content } };

--- a/features/idvtc/dkg/utils/validate-dkg-file.ts
+++ b/features/idvtc/dkg/utils/validate-dkg-file.ts
@@ -1,7 +1,10 @@
 import type { DkgFileUploadItem } from '../types';
 
 export const MAX_NAME_LENGTH = 255;
-export const MAX_CONTENT_BYTES = 5 * 1024 * 1024; // 5 MiB after JSON.stringify
+// 4 MB after JSON.stringify — deliberately stricter than the API's own 5 MiB
+// per-file cap, so an oversized file is rejected client-side before the
+// server ever sees it.
+export const MAX_CONTENT_BYTES = 4 * 1024 * 1024;
 
 export type ValidateResult =
   { ok: true; item: DkgFileUploadItem } | { ok: false; reason: string };
@@ -35,7 +38,7 @@ export const validateDkgFile = (name: string, text: string): ValidateResult => {
   }
 
   if (byteLength(JSON.stringify(content)) > MAX_CONTENT_BYTES) {
-    return { ok: false, reason: 'File is larger than 5 MB' };
+    return { ok: false, reason: 'File is larger than 4 MB' };
   }
 
   return { ok: true, item: { name, content } };

--- a/modules/surveys-sdk/api/__tests__/survey-client.test.ts
+++ b/modules/surveys-sdk/api/__tests__/survey-client.test.ts
@@ -325,5 +325,26 @@ describe('survey-client / callSurvey', () => {
       expect(err).toBeInstanceOf(SurveysApiError);
       expect(authErrorKind(err)).toBeUndefined();
     });
+
+    it('surfaces a rejected fetch (CORS/network failure) — probing the interceptor comment', async () => {
+      // A CORS-blocked response (e.g. a 413 with no Access-Control-Allow-Origin
+      // header) or a genuine network outage makes the browser's `fetch` reject
+      // outright — no Response ever exists. This proves what actually reaches
+      // the caller in that case.
+      const networkError = new TypeError('Failed to fetch');
+      (globalThis as unknown as { fetch: jest.Mock }).fetch = jest
+        .fn()
+        .mockRejectedValue(networkError);
+
+      const err = await captureError(() =>
+        callSurvey(() =>
+          openIndex({ ...surveyRequest(), path: { nodeOperatorId: 'csm-1' } }),
+        ),
+      );
+
+      expect(err).toBeInstanceOf(SurveysApiError);
+      expect(err.status).toBe(0);
+      expect(err.cause).toBe(networkError);
+    });
   });
 });

--- a/modules/surveys-sdk/generated/types.gen.ts
+++ b/modules/surveys-sdk/generated/types.gen.ts
@@ -207,7 +207,7 @@ export type FileUploadItemDto = {
      */
     name: string;
     /**
-     * Arbitrary JSON-serializable content (≤ 64 KB after JSON.stringify). Typically a JSON object.
+     * Arbitrary JSON-serializable content (≤ 5 MiB after JSON.stringify). Typically a JSON object.
      */
     content: {
         [key: string]: unknown;

--- a/modules/surveys-sdk/openapi/survey-api.json
+++ b/modules/surveys-sdk/openapi/survey-api.json
@@ -2660,7 +2660,7 @@
   "info": {
     "title": "CSM Survey API",
     "description": "",
-    "version": "0.7.0",
+    "version": "0.7.2",
     "contact": {}
   },
   "tags": [
@@ -3086,7 +3086,7 @@
           "content": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Arbitrary JSON-serializable content (≤ 64 KB after JSON.stringify). Typically a JSON object."
+            "description": "Arbitrary JSON-serializable content (≤ 5 MiB after JSON.stringify). Typically a JSON object."
           }
         },
         "required": [

--- a/shared/hook-form/validation/messages.ts
+++ b/shared/hook-form/validation/messages.ts
@@ -135,4 +135,7 @@ export const validationMessage = {
   // Splits: max additional addresses (dynamic count)
   maxAdditionalAddressesDynamic: (max: number): string =>
     `Maximum ${max} additional addresses`,
+
+  dkgBatchTooLarge: (maxLabel: string): string =>
+    `Total size of DKG files exceeds ${maxLabel}`,
 } as const;


### PR DESCRIPTION
csm-surveys-api raised the per-file upload cap from 64 KB to 4 MiB and added a per-operator quota (100 MiB / 1000 files). Sync the client side, plus fixes from testing large uploads against hoodi.

**Per-file limits**

- `MAX_CONTENT_BYTES` set to 4 MB, mirroring the API's own per-file cap, so an oversized file is rejected before the server sees it
- add copy for the new `FILES_QUOTA_EXCEEDED` / `FILES_COUNT_EXCEEDED` codes, which otherwise fall back to the server message and show raw byte counts
- re-pull the OpenAPI spec (0.7.0 -> 0.7.2) and regenerate

**Total batch size**

The endpoint POSTs the whole batch as one JSON array, so a batch can blow the API's `BODY_LIMIT` (4,300,000 bytes) even when every file passes. `validate-dkg-batch.ts` caps the batch at that limit, enforced on the `dkgFiles` field of both flows (`/keys/submit`, `/create`) and on the standalone `/idvtc/dkg` drop handler. The field error disables submit through the existing `hasErrors` path, and the staged list shows a running total. This matters because the in-flow upload runs *after* the tx — without it, an oversized batch means keys submitted and files lost.

As a backstop, an over-limit body that does reach the server returns a 413 with no `Access-Control-Allow-Origin` header, so the browser blocks it and `fetch` rejects with no HTTP status. That opaque failure is reclassified into a client-side `FILES_PAYLOAD_TOO_LARGE` with operator-facing copy.

**Stuck modal**

A failed in-flow DKG upload left the tx modal spinning forever: `uploadStaged` set a non-terminal pending stage but left the terminal state to its callers, and the add-keys flow's catch only called `handleTxError` — a predicate that transits nothing. The hook that sets the pending stage now owns the terminal failure state too.

Total quota and file count stay backend-enforced. Two figures were also wrong and are corrected: `SERVER_BODY_LIMIT_BYTES` claimed 6 MiB, and the per-file comment claimed the API allowed 5 MiB (it is the same 4 MiB).
