### PR TITLE
feat: raise keys-per-tx limit to 75 and flag overflow keys in validation

### DIFF
--- a/consts/keys.ts
+++ b/consts/keys.ts
@@ -1,1 +1,1 @@
-export const KEYS_UPLOAD_TX_LIMIT = 25;
+export const KEYS_UPLOAD_TX_LIMIT = 75;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@lidofinance/api-rpc": "^0.61.0",
     "@lidofinance/eth-api-providers": "^0.61.0",
     "@lidofinance/eth-providers": "^0.61.0",
-    "@lidofinance/lido-csm-sdk": "2.0.0-alpha.74",
+    "@lidofinance/lido-csm-sdk": "2.0.0-alpha.75",
     "@lidofinance/lido-ethereum-sdk": "^4.8.0",
     "@lidofinance/lido-ui": "^3.42.1",
     "@lidofinance/next-api-wrapper": "^0.61.0",

--- a/shared/hook-form/validation/messages.ts
+++ b/shared/hook-form/validation/messages.ts
@@ -9,6 +9,7 @@ import { pluralKeys } from 'utils/plural';
 export const VALIDATION_MESSAGES = {
   // Deposit data
   invalidDepositData: 'Invalid deposit data',
+  keyExceedsTxLimit: 'Exceeds the keys per transaction limit',
 
   // Address / hex
   invalidAddress: 'Enter a valid Ethereum address',

--- a/shared/hook-form/validation/validate-deposit-data.ts
+++ b/shared/hook-form/validation/validate-deposit-data.ts
@@ -21,37 +21,49 @@ export const validateDepositData = async ({
 }: ValidateDepositDataProps) => {
   if (!depositData?.length) return;
 
-  // 1. SDK validation of deposit data structure
-  const errors = await sdk.validateDepositData(depositData, { skipSignature });
+  const exceedsTxLimit = depositData.length > KEYS_UPLOAD_TX_LIMIT;
 
-  if (errors?.length) {
-    const types = mapValues(groupBy(errors, 'index'), (errors) => {
-      const withField = errors.filter((e) => e.field);
-      const withoutField = errors.filter((e) => !e.field);
-      const uniqueWithField = uniqBy(withField, 'field');
-      return [...uniqueWithField, ...withoutField].map(
-        (error) => error.message,
-      );
-    });
+  // 1. SDK validation of deposit data structure.
+  // Keys beyond the tx limit are not sent to the SDK — signature checks are
+  // expensive and the submission is rejected anyway; they get a per-row error.
+  const errors = await sdk.validateDepositData(
+    exceedsTxLimit ? depositData.slice(0, KEYS_UPLOAD_TX_LIMIT) : depositData,
+    { skipSignature },
+  );
+
+  if (errors?.length || exceedsTxLimit) {
+    const types: Record<string, string[]> = mapValues(
+      groupBy(errors, 'index'),
+      (errors) => {
+        const withField = errors.filter((e) => e.field);
+        const withoutField = errors.filter((e) => !e.field);
+        const uniqueWithField = uniqBy(withField, 'field');
+        return [...uniqueWithField, ...withoutField].map(
+          (error) => error.message,
+        );
+      },
+    );
+
+    for (
+      let index = KEYS_UPLOAD_TX_LIMIT;
+      index < depositData.length;
+      index++
+    ) {
+      types[index] = [VALIDATION_MESSAGES.keyExceedsTxLimit];
+    }
 
     throw new ValidationError(
       'depositData',
-      VALIDATION_MESSAGES.invalidDepositData,
+      exceedsTxLimit
+        ? validationMessage.tooManyKeys(KEYS_UPLOAD_TX_LIMIT)
+        : VALIDATION_MESSAGES.invalidDepositData,
       undefined,
       undefined,
       types,
     );
   }
 
-  // 2. Transaction limit check (25 keys per transaction)
-  if (depositData.length > KEYS_UPLOAD_TX_LIMIT) {
-    throw new ValidationError(
-      'depositData',
-      validationMessage.tooManyKeys(KEYS_UPLOAD_TX_LIMIT),
-    );
-  }
-
-  // 3. Operator keys limit check
+  // 2. Operator keys limit check
   if (keysLimit !== undefined) {
     const keysCount = depositData.length;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,10 +2490,10 @@
   resolved "https://registry.yarnpkg.com/@lidofinance/eth-providers/-/eth-providers-0.61.0.tgz#4e26bcf239b1afb7971d80fcda97bb683a7badef"
   integrity sha512-tRy/I9egYHcg7gTMrEnhLS799yhO9IjwrQmmXvM9+gRAw3AZJUzj1lYK4sgClxtV8kGZU6XejOk8OkRTmryUAg==
 
-"@lidofinance/lido-csm-sdk@2.0.0-alpha.74":
-  version "2.0.0-alpha.74"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-csm-sdk/-/lido-csm-sdk-2.0.0-alpha.74.tgz#6ef88ed73b282c4e341c7add4eff28fa80b9c5ad"
-  integrity sha512-uXt4l27adIoJ4AHUSVuiZY/vxG6DYeDpS3FECBPJvq0wghnKGjGisFXP2wX7yj+uV6uIegVW2OCuhpy7w7mVSQ==
+"@lidofinance/lido-csm-sdk@2.0.0-alpha.75":
+  version "2.0.0-alpha.75"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-csm-sdk/-/lido-csm-sdk-2.0.0-alpha.75.tgz#81aca56ba4fe52481880968f48cfc58f4c470eba"
+  integrity sha512-h+TYqBhW47HFglcfVhRrhTk9Q5KHFtPotFobTGsb1fo6ZlX+GePyQ9yH4i2Fdmauv6wnCPKRcpceP/Tz5zgeXw==
   dependencies:
     "@chainsafe/ssz" "^1.3.0"
     "@openzeppelin/merkle-tree" "^1.0.8"


### PR DESCRIPTION
## Changes

- Raise `KEYS_UPLOAD_TX_LIMIT` from 25 to **75**
- `validateDepositData`: when the uploaded file exceeds the tx limit, only the first 75 keys are passed to SDK validation (skips expensive signature checks for keys that would be rejected anyway); every key beyond the limit gets a per-row "Exceeds the keys per transaction limit" error in the Parsed tab, and the main form error is the `tooManyKeys` message
- Update `@lidofinance/lido-csm-sdk` to `2.0.0-alpha.75`

## Testing

- `yarn lint:fix` and `yarn tsc --noEmit` pass