### PR TITLE
fix: disable feature flags on mainnet and update QA feature flags

### DIFF
--- a/config/feature-flags/context-hook.tsx
+++ b/config/feature-flags/context-hook.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useLocalStorage } from 'shared/hooks/use-local-storage';
 import { FeatureFlagsType } from './types';
-import { getFeatureFlagsDefault } from './utils';
+import { getFeatureFlagsDefault, isMainnet } from './utils';
 
 const STORAGE_FEATURE_FLAGS = 'lido-feature-flags';
 
@@ -21,11 +21,14 @@ export const useFeatureFlagsContext = () => {
   );
 
   useEffect(() => {
+    // turn off feature flags on mainnet
+    if (isMainnet) return;
     setFeatureFlagsState(featureFlagsLocalStorage);
   }, [featureFlagsLocalStorage]);
 
   const setFeatureFlag = useCallback(
     (featureFlag: keyof FeatureFlagsType, value: boolean) => {
+      if (isMainnet) return;
       const newFlags = {
         ...featureFlagsState,
         [featureFlag]: value,

--- a/config/feature-flags/utils.ts
+++ b/config/feature-flags/utils.ts
@@ -10,7 +10,7 @@ import {
 } from './types';
 
 const { defaultChain } = getConfig();
-const isMainnet = defaultChain === CHAINS.Mainnet;
+export const isMainnet = defaultChain === CHAINS.Mainnet;
 
 export const getFeatureFlagsDefault = (): FeatureFlagsType => {
   return {

--- a/features/qa-config/qa-feature-flags.tsx
+++ b/features/qa-config/qa-feature-flags.tsx
@@ -32,6 +32,9 @@ const FLAGS = Object.keys(getFeatureFlagsDefault()) as Array<
 const TESTNET_ONLY_FLAGS: Array<keyof FeatureFlagsType> = [
   ICS_APPLY_FORM,
   SURVEYS_SETUP_ENABLED,
+  DISABLE_DEPOSIT_DATA_VALIDATION,
+  DISABLE_ICS_PROOF_VALIDATION,
+  DISABLE_DEPOSIT_DATA_SIGNATURE_VALIDATION,
 ];
 
 export const QaFeatureFlags: FC = () => {
@@ -46,7 +49,7 @@ export const QaFeatureFlags: FC = () => {
     [defaultChain],
   );
 
-  if (!featureFlags) return null;
+  if (!featureFlags || flags.length === 0) return null;
 
   return (
     <FormBlock>


### PR DESCRIPTION
## Description

Disabled the use of feature flags on mainnet:

- Removed the ability to set flags through the `qa-config` UI on mainnet.
- Removed the ability to set flags directly in `localStorage`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

- [ ] Requires other services change
- [ ] Affects to other services
- [ ] Requires dependency update
- [ ] Automated tests
- [ ] Looks good on large screens
- [ ] Looks good on mobile
