### PR TITLE
ci: bind setup-just version via env before shell

### DIFF
--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -31,4 +31,6 @@ runs:
     - name: Install just
       if: steps.get-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: cargo install --locked "just@${{ inputs.version }}"
+      env:
+        JUST_VERSION: ${{ inputs.version }}
+      run: cargo install --locked "just@${JUST_VERSION}"


### PR DESCRIPTION
## Summary
The `setup-just` composite action interpolated `inputs.version` directly into a `run:` script (`cargo install --locked "just@${{ inputs.version }}"`). Move the value into `env:` and expand `"just@${JUST_VERSION}"` in the shell instead.

## Test plan
- [ ] Workflow that uses `setup-just` still installs the default `just` version on cache miss
- [ ] Cache key behavior unchanged (`just:${{ inputs.version }}` remains in the cache-params step)


Made with [Cursor](https://cursor.com)